### PR TITLE
authentication via Auth0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==1.0.2
 requests==2.21.0
 pandas==0.24.2
+flask-dance

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -18,8 +18,9 @@ def create_app(config=None):
     def protect_endpoint():
         if not auth0.authorized:
             # means we have a token, not necessarily that it
-            # hasn't expired, but the oauth session should
-            # refresh if needed
+            # hasn't expired, but refreshing is handled
+            # by request_oauthlib and oauthlib
+            # and the api validates expiration
             return redirect(url_for('auth0.login'))
 
     from sfa_dash.blueprints.main import data_dash_blp

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, redirect, url_for
+from flask import Flask, redirect, url_for, render_template
 
 
 from sfa_dash.blueprints.auth0 import make_auth0_blueprint, auth0, logout
@@ -22,6 +22,13 @@ def create_app(config=None):
             # by request_oauthlib and oauthlib
             # and the api validates expiration
             return redirect(url_for('auth0.login'))
+
+    @app.route('/')
+    def index():
+        # move index to app so all blueprints are secured
+        # should probably test if auth0.authorized and show one
+        # page, show a different page w/ login link otherwise
+        return render_template('index.html')
 
     from sfa_dash.blueprints.main import data_dash_blp
     from sfa_dash.blueprints.form import forms_blp

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -1,14 +1,33 @@
-from flask import Flask
+from flask import Flask, redirect, url_for
 
 
-def create_app():
+from sfa_dash.blueprints.auth0 import make_auth0_blueprint, auth0, logout
+
+
+def create_app(config=None):
     app = Flask(__name__)
-    app.secret_key = b'_24nsdagnnt2#%53moz'
-    app.config.from_object('sfa_dash.config.LocalConfig')
-    from blueprints.main import data_dash_blp
-    from blueprints.form import forms_blp
-    app.register_blueprint(data_dash_blp)
-    app.register_blueprint(forms_blp)
+    config = config or 'sfa_dash.config.DevConfig'
+    app.config.from_object(config)
+    app.secret_key = app.config['SECRET_KEY']
+
+    auth0_bp = make_auth0_blueprint(
+        base_url=app.config['AUTH0_OAUTH_BASE_URL'])
+    app.register_blueprint(auth0_bp, url_prefix='/login')
+    app.route('/logout')(logout)
+
+    def protect_endpoint():
+        if not auth0.authorized:
+            # means we have a token, not necessarily that it
+            # hasn't expired, but the oauth session should
+            # refresh if needed
+            return redirect(url_for('auth0.login'))
+
+    from sfa_dash.blueprints.main import data_dash_blp
+    from sfa_dash.blueprints.form import forms_blp
+
+    for blp in (data_dash_blp, forms_blp):
+        blp.before_request(protect_endpoint)
+        app.register_blueprint(blp)
     return app
 
 

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -1,7 +1,8 @@
 from flask import Flask, redirect, url_for, render_template
 
 
-from sfa_dash.blueprints.auth0 import make_auth0_blueprint, auth0, logout
+from sfa_dash.blueprints.auth0 import (make_auth0_blueprint, logout,
+                                       oauth_request_session)
 
 
 def create_app(config=None):
@@ -16,7 +17,7 @@ def create_app(config=None):
     app.route('/logout')(logout)
 
     def protect_endpoint():
-        if not auth0.authorized:
+        if not oauth_request_session.authorized:
             # means we have a token, not necessarily that it
             # hasn't expired, but refreshing is handled
             # by request_oauthlib and oauthlib
@@ -26,7 +27,7 @@ def create_app(config=None):
     @app.route('/')
     def index():
         # move index to app so all blueprints are secured
-        # should probably test if auth0.authorized and show one
+        # should probably test if authorized and show one
         # page, show a different page w/ login link otherwise
         return render_template('index.html')
 

--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -1,7 +1,9 @@
 """Helper functions for all Solar Forecast Arbiter /sites/* endpoints.
 """
 from flask import current_app as app
-import requests
+
+
+from sfa_dash import auth0
 
 
 def get_request(path, **kwargs):
@@ -17,7 +19,13 @@ def get_request(path, **kwargs):
     requests.Response
         The api response.
     """
-    return requests.get(f'{app.config["SFA_API_URL"]}{path}', **kwargs)
+    try:
+        session = auth0  # already has token ready to use for api
+    except Exception:
+        # make a requests session?
+        # redirect to login?
+        raise
+    return session.get(f'{app.config["SFA_API_URL"]}{path}', **kwargs)
 
 
 def post_request(path, payload, json=True):
@@ -39,9 +47,10 @@ def post_request(path, payload, json=True):
     requests.Response
         The api response.
     """
+    session = auth0
     if json:
-        return requests.post(f'{app.config["SFA_API_URL"]}{path}',
-                             json=payload)
-    return requests.post(f'{app.config["SFA_API_URL"]}{path}',
-                         headers={'Content-type': 'text/csv'},
-                         data=payload)
+        return session.post(f'{app.config["SFA_API_URL"]}{path}',
+                            json=payload)
+    return session.post(f'{app.config["SFA_API_URL"]}{path}',
+                        headers={'Content-type': 'text/csv'},
+                        data=payload)

--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -3,7 +3,7 @@
 from flask import current_app as app
 
 
-from sfa_dash import auth0
+from sfa_dash import oauth_request_session
 
 
 def get_request(path, **kwargs):
@@ -19,13 +19,9 @@ def get_request(path, **kwargs):
     requests.Response
         The api response.
     """
-    try:
-        session = auth0  # already has token ready to use for api
-    except Exception:
-        # make a requests session?
-        # redirect to login?
-        raise
-    return session.get(f'{app.config["SFA_API_URL"]}{path}', **kwargs)
+    # may need to handle errors if oauth_request_session does not exist somehow
+    return oauth_request_session.get(
+            f'{app.config["SFA_API_URL"]}{path}', **kwargs)
 
 
 def post_request(path, payload, json=True):
@@ -47,10 +43,10 @@ def post_request(path, payload, json=True):
     requests.Response
         The api response.
     """
-    session = auth0
     if json:
-        return session.post(f'{app.config["SFA_API_URL"]}{path}',
-                            json=payload)
-    return session.post(f'{app.config["SFA_API_URL"]}{path}',
-                        headers={'Content-type': 'text/csv'},
-                        data=payload)
+        kwargs = {'json': payload}
+    else:
+        kwargs = {'headers': {'Content-type': 'text/csv'},
+                  'data': payload}
+    return oauth_request_session.post(
+        f'{app.config["SFA_API_URL"]}{path}', **kwargs)

--- a/sfa_dash/blueprints/auth0.py
+++ b/sfa_dash/blueprints/auth0.py
@@ -11,7 +11,7 @@ from flask_dance.consumer import OAuth2ConsumerBlueprint
 from six.moves.urllib.parse import urlencode
 
 
-auth0 = LocalProxy(partial(_lookup_app_object, 'auth0_oauth'))
+oauth_request_session = LocalProxy(partial(_lookup_app_object, 'auth0_oauth'))
 
 
 def logout():
@@ -56,7 +56,7 @@ def make_auth0_blueprint(
         # can probably just decode the id_token
         # might also want to make a current_user proxy with the
         # sub or email
-        userinfo = auth0.get(f'{base_url}/userinfo').json()
+        userinfo = oauth_request_session.get(f'{base_url}/userinfo').json()
         session['userinfo'] = userinfo
         return redirect(url_for('index'))
 

--- a/sfa_dash/blueprints/auth0.py
+++ b/sfa_dash/blueprints/auth0.py
@@ -5,8 +5,23 @@ try:
     from flask import _app_ctx_stack as stack
 except ImportError:
     from flask import _request_ctx_stack as stack
+from flask import url_for, redirect, current_app, session
 from flask.globals import LocalProxy, _lookup_app_object
 from flask_dance.consumer import OAuth2ConsumerBlueprint
+from six.moves.urllib.parse import urlencode
+
+
+auth0 = LocalProxy(partial(_lookup_app_object, 'auth0_oauth'))
+
+
+def logout():
+    session.clear()
+    params = {'returnTo': url_for('data_dashboard.root_redirect',
+                                  _external=True),
+              'client_id': current_app.config['AUTH0_OAUTH_CLIENT_ID']}
+    return redirect(
+        current_app.config['AUTH0_OAUTH_BASE_URL'] + '/v2/logout?'
+        + urlencode(params))
 
 
 def make_auth0_blueprint(
@@ -41,6 +56,3 @@ def make_auth0_blueprint(
         ctx.auth0_oauth = auth0_bp.session
 
     return auth0_bp
-
-
-auth0 = LocalProxy(partial(_lookup_app_object, 'auth0_oauth'))

--- a/sfa_dash/blueprints/auth0.py
+++ b/sfa_dash/blueprints/auth0.py
@@ -16,7 +16,7 @@ auth0 = LocalProxy(partial(_lookup_app_object, 'auth0_oauth'))
 
 def logout():
     session.clear()
-    params = {'returnTo': url_for('data_dashboard.root_redirect',
+    params = {'returnTo': url_for('index',
                                   _external=True),
               'client_id': current_app.config['AUTH0_OAUTH_CLIENT_ID']}
     return redirect(
@@ -53,6 +53,6 @@ def make_auth0_blueprint(
     def callback_handling():
         userinfo = auth0.get(f'{base_url}/userinfo').json()
         session['userinfo'] = userinfo
-        return redirect(url_for('data_dashboard.root_redirect'))
+        return redirect(url_for('index'))
 
     return auth0_bp

--- a/sfa_dash/blueprints/auth0.py
+++ b/sfa_dash/blueprints/auth0.py
@@ -1,0 +1,46 @@
+from functools import partial
+
+
+try:
+    from flask import _app_ctx_stack as stack
+except ImportError:
+    from flask import _request_ctx_stack as stack
+from flask.globals import LocalProxy, _lookup_app_object
+from flask_dance.consumer import OAuth2ConsumerBlueprint
+
+
+def make_auth0_blueprint(
+        base_url, client_id=None, client_secret=None,
+        scope=None, redirect_url=None,
+        redirect_to=None, login_url=None,
+        session_class=None,
+        storage=None):
+    scope = scope or ['openid', 'email', 'profile', 'offline_access']
+    auth0_bp = OAuth2ConsumerBlueprint(
+        'auth0', __name__,
+        client_id=client_id,
+        client_secret=client_secret,
+        base_url=base_url,
+        token_url=f'{base_url}/oauth/token',
+        authorization_url=f'{base_url}/authorize',
+        authorization_url_params={
+            'audience': 'https://api.solarforecastarbiter.org'},
+        redirect_url=redirect_url,
+        redirect_to=redirect_to,
+        scope=scope,
+        login_url=login_url,
+        session_class=session_class,
+        storage=storage,
+        )
+    auth0_bp.from_config['client_id'] = 'AUTH0_OAUTH_CLIENT_ID'
+    auth0_bp.from_config['client_secret'] = 'AUTH0_OAUTH_CLIENT_SECRET'
+
+    @auth0_bp.before_app_request
+    def set_applocal_session():
+        ctx = stack.top
+        ctx.auth0_oauth = auth0_bp.session
+
+    return auth0_bp
+
+
+auth0 = LocalProxy(partial(_lookup_app_object, 'auth0_oauth'))

--- a/sfa_dash/blueprints/auth0.py
+++ b/sfa_dash/blueprints/auth0.py
@@ -37,6 +37,7 @@ def make_auth0_blueprint(
         client_secret=client_secret,
         base_url=base_url,
         token_url=f'{base_url}/oauth/token',
+        auto_refresh_url=f'{base_url}/oauth/token',
         authorization_url=f'{base_url}/authorize',
         authorization_url_params={
             'audience': 'https://api.solarforecastarbiter.org'},

--- a/sfa_dash/blueprints/auth0.py
+++ b/sfa_dash/blueprints/auth0.py
@@ -28,7 +28,9 @@ def make_auth0_blueprint(
         base_url,
         scope=None,
         storage=None):
-    scope = scope or ['openid', 'email', 'profile', 'offline_access']
+    scope = scope or ['openid', 'email', 'profile']
+    # add 'offline_access' to the scope once secure storage is implemented
+    # so the refresh token can be stored and used
     auth0_bp = OAuth2ConsumerBlueprint(
         'auth0', __name__,
         base_url=base_url,
@@ -51,6 +53,9 @@ def make_auth0_blueprint(
 
     @auth0_bp.route('/callback')
     def callback_handling():
+        # can probably just decode the id_token
+        # might also want to make a current_user proxy with the
+        # sub or email
         userinfo = auth0.get(f'{base_url}/userinfo').json()
         session['userinfo'] = userinfo
         return redirect(url_for('index'))

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -105,14 +105,6 @@ class TrialsView(DataDashView):
     template = 'data/trials.html'
 
 
-class ToSites(MethodView):
-    """Temporary redirect to sites until landing/homepage is
-    designed.
-    """
-    def get(self):
-        return redirect(url_for('data_dashboard.sites_view'), 302)
-
-
 data_dash_blp = Blueprint('data_dashboard', 'data_dashboard')
 data_dash_blp.add_url_rule(
     '/sites/',
@@ -141,6 +133,3 @@ data_dash_blp.add_url_rule(
 data_dash_blp.add_url_rule(
     '/forecasts/<uuid>',
     view_func=SingleForecastView.as_view('forecast_view'))
-
-# Temporary redirect to sites page
-data_dash_blp.add_url_rule('/', view_func=ToSites.as_view('root_redirect'))

--- a/sfa_dash/config.py
+++ b/sfa_dash/config.py
@@ -1,7 +1,17 @@
-class LocalConfig(object):
+import os
+
+
+class BaseConfig(object):
+    SECRET_KEY = os.getenv('FLASK_SECRET_KEY', os.urandom(32))
+    AUTH0_OAUTH_CLIENT_ID = os.getenv('AUTH0_CLIENT_ID', '')
+    AUTH0_OAUTH_CLIENT_SECRET = os.getenv('AUTH0_CLIENT_SECRET', '')
+    AUTH0_OAUTH_BASE_URL = 'https://solarforecastarbiter.auth0.com'
+
+
+class LocalConfig(BaseConfig):
     SFA_API_URL = 'http://localhost:5000'
     TEMPLATES_AUTO_RELOAD = True
 
 
-class DevConfig(object):
+class DevConfig(BaseConfig):
     SFA_API_URL = 'https://dev-api.solarforecastarbiter.org'

--- a/sfa_dash/serve.py
+++ b/sfa_dash/serve.py
@@ -1,5 +1,7 @@
+import os
 from sfa_dash import create_app
 
 
-app = create_app()
+os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+app = create_app('sfa_dash.config.LocalConfig')
 app.run(port=8080)

--- a/sfa_dash/templates/index.html
+++ b/sfa_dash/templates/index.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block dash %}
+<h2 class="page-title">Welcome</h2>
+{% include "dash/subnav.html" %}
+{% endblock %}


### PR DESCRIPTION
uses flask-dance blueprint to add a /login/auth0 path to log users in. Right now, tokens are stored in the client session cookie which ok for testing for now. Should implement storage on the backend and then we can also use refresh tokens. Also need the client id and secret from auth0 even for local testing 