### PR TITLE
Authentication links

### DIFF
--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -1,4 +1,4 @@
-from flask import Flask, redirect, url_for, render_template
+from flask import Flask, redirect, url_for, render_template, session
 
 
 from sfa_dash.blueprints.auth0 import (make_auth0_blueprint, logout,
@@ -36,9 +36,11 @@ def create_app(config=None):
 
     @app.context_processor
     def inject_globals():
-        # Injects variables provided in template_globals
-        # into all templates.
-        return template_variables()
+        # Injects variables into all rendered templates
+        global_template_args = {}
+        global_template_args['user'] = session.get('userinfo')
+        global_template_args.update(template_variables())
+        return global_template_args
 
     from sfa_dash.blueprints.main import data_dash_blp
     from sfa_dash.blueprints.form import forms_blp

--- a/sfa_dash/templates/base.html
+++ b/sfa_dash/templates/base.html
@@ -3,7 +3,6 @@
   <head>
     {% include "head.html" %}
   </head>
-
   <body class="d-flex flex-column h-100">
     <header>
       {% include "navbar.html" %}
@@ -12,7 +11,10 @@
       <div class="container">
 	  	<!-- Content Block -->
 		  <div class="row">
-			{% if True %} {# if sidebar is defined #}
+            {% if sidebar is not defined %}
+            {% set sidebar = True %}
+            {% endif %}
+			{% if sidebar %}
 		    {% include "sidebar.html" %} 
 		    <div class="content col-sm-9 col-xs-12">
 			{% else %}

--- a/sfa_dash/templates/forms/cdf_forecast_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_form.html
@@ -16,7 +16,7 @@
 	</div>
 	<div class="form-element">
       {{ form.select('Variable', 'variable',
-                     variable_options
+                     variable_options,
                      form_data=form_data) }}
 	</div>
     <div class="form-element">

--- a/sfa_dash/templates/index.html
+++ b/sfa_dash/templates/index.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
+{% if user is none %}
+{% set sidebar = False %}
+{% endif %}
 {% block dash %}
 <h2 class="page-title">Welcome</h2>
+{% if user is none %}
+<p>Please <a href="{{ url_for('auth0.login') }}">login</a> to access the dashboard.</p>
+{% endif %}
 {% include "dash/subnav.html" %}
 {% endblock %}

--- a/sfa_dash/templates/navbar.html
+++ b/sfa_dash/templates/navbar.html
@@ -25,9 +25,7 @@
               Account
             </button>
             <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-              <a class="dropdown-item" href="#">Link1</a>
-              <a class="dropdown-item" href="#">Link2</a>
-              <a class="dropdown-item" href="#">Link3</a>
+                <a class="dropdown-item" href="{{ url_for('logout') }}">Logout</a>
             </div>
           </div>
 		</li>

--- a/sfa_dash/templates/navbar.html
+++ b/sfa_dash/templates/navbar.html
@@ -25,7 +25,13 @@
               Account
             </button>
             <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
-                <a class="dropdown-item" href="{{ url_for('logout') }}">Logout</a>
+              {% if user is not none %}
+              <div class= "dropdown-item"><b>Logged in as:</b><br/> {{ user['name'] }}</div>
+              <a class="dropdown-item" href="{{ url_for('logout') }}">Log out</a>
+              {% else %}
+              <a class="dropdown-item" href="{{ url_for('auth0.login') }}">Log in</a>
+              {% endif %}
+
             </div>
           </div>
 		</li>


### PR DESCRIPTION
closes #15 and adds a few more things:
- adds Log in/Log out link to the `Account` menu in the top right
- For unauthenticated users, Hides the sidebar on the landing page and displays a 'Please log in to access the dashboard.' message. 
- For authenticated users the Account menu has a "Logged in as: <email>" and log out link.
- Fixes a typo introduced in #30 causing an error to be thrown on the cdf_forecast_form.
