### PR TITLE
manually activated tooltips

### DIFF
--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -348,9 +348,8 @@ class DownloadForm(BaseView):
             Query parameters start and end, both formatted in iso8601 and
             localized to the provided timezone.
         """
-        timezone = form_data['timezone']
-        start_time = pd.Timestamp(form_data['period-start'], tz=timezone)
-        end_time = pd.Timestamp(form_data['period-end'], tz=timezone)
+        start_time = pd.Timestamp(form_data['period-start'], tz='utc')
+        end_time = pd.Timestamp(form_data['period-end'], tz='utc')
         params = {
             'start': start_time.isoformat(),
             'end': end_time.isoformat(),

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -145,8 +145,17 @@ ul.data-metadata-fields{
 .form-element label{
   font-weight: 600;
 }
+@media (min-width: 769px) {
+  .form-element{
+    width: 50%;
+  }
+}
+@media (max-width: 768px){
+  .form-element{
+    width: 100%;
+  }
+}
 .form-element{
-  width: 50%;
   float: left;
   padding: .5em 1em;
   position: relative;
@@ -175,7 +184,6 @@ pre.example-text{
   padding: 1em;
 }
 span.help-text{
-  display: none;
   width: 100%;
   padding: .5em;
   border: 2px solid #6c757d;
@@ -196,21 +204,6 @@ span.help-text::before {
   border-style: solid;
   border-color: transparent transparent #6c757d transparent;
 }
-span.help-text.time-field-help::before {
-  left: 20%;
-}
-span.help-text.help-text-top{
-  bottom: 3.5em;
-}
-span.help-text.help-text-top::before{
-  border-color: #6c757d transparent transparent transparent;
-  top: unset;
-  bottom: -13px;
-}
-
-[class$="-field"]:focus ~ span.help-text{
-  display: block;
-}
 ul.error-list{
   list-style: none;
 }
@@ -223,4 +216,17 @@ li.alert p{
 pre.example-text{
     overflow: scroll;
     max-width: 761px;
+}
+a.help-button{
+    color: white;
+    font-weight: bolder;
+    background-color: #6c757d;
+    border-radius: 12px;
+    width: 24px;
+    display: inline-block;
+    text-align: center;
+}
+.input-wrapper{
+    width: calc(100% - 28px);
+    display: inline-block;
 }

--- a/sfa_dash/templates/forms/cdf_forecast_download_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_download_form.html
@@ -15,12 +15,6 @@
 	  <label for="end">End time:</label>
 	  <input type="datetime-local" id="end" name="period-end">
     </div>
-	<div class="form-element">
-	  <label>Timezone</label>
-	  <select required name="timezone" class="form-control">
-        <option value="utc">UTC</option>
-      </select>
-	</div>
 	<div class="form-element full-width">
 	  <label for="format">Format</label><br/>
 	  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>

--- a/sfa_dash/templates/forms/cdf_forecast_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_form.html
@@ -21,7 +21,7 @@
 	</div>
     <div class="form-element">
       {{ form.time_of_day('Issue time of day', 'issue_time',
-                          'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }} UTC
+                          'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }}
     </div>
     <div class="form-element">
         {{ form.timedelta('Lead time to start', 'lead_time',

--- a/sfa_dash/templates/forms/forecast_download_form.html
+++ b/sfa_dash/templates/forms/forecast_download_form.html
@@ -15,12 +15,6 @@
 	  <label for="end">End time:</label>
 	  <input type="datetime-local" id="end" name="period-end">
     </div>
-	<div class="form-element">
-	  <label>Timezone</label>
-	  <select required name="timezone" class="form-control">
-        <option value="utc">UTC</option>
-      </select>
-	</div>
 	<div class="form-element full-width">
 	  <label for="format">Format</label><br/>
 	  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -21,7 +21,7 @@
 	</div>
     <div class="form-element">
       {{ form.time_of_day('Issue time of day', 'issue_time',
-                          'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }} UTC
+                          'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }}
     </div>
     <div class="form-element">
         {{ form.timedelta('Lead time to start', 'lead_time',

--- a/sfa_dash/templates/forms/form_macros.jinja
+++ b/sfa_dash/templates/forms/form_macros.jinja
@@ -1,3 +1,7 @@
+{% macro help_button(name) %}
+<a data-toggle="collapse" data-target=".{{ name }}-help-text" role="button" href="" class="help-button">?</a>
+{% endmacro %}
+
 {% macro input(label, type, name, help_text=None, form_data=None, required=False, class='', default='') %}
 {% set extra_attr = '' %}
 
@@ -8,43 +12,63 @@
 {% if required %}
 {% set extra_attr = extra_attr + ' required' %}
 {% endif %}
-
-<label>{{ label }}</label>
+<label>{{ label }}</label><br/>
+<div class="input-wrapper">
 <input type="{{ type }}" class="form-control {{ class }} {{ name }}-field" {{ extra_attr }}  name="{{ name }}" {% if form_data is not none %}value="{{ form_data.get(name, default) }}"{% endif %}>
-{% if help_text is not none %}<span class="form-text text-muted help-text">{{ help_text }}</span>{% endif %}
+</div>
+{% if help_text is not none %}
+{{ help_button(name) }}
+<span class="{{ name }}-help-text form-text text-muted help-text collapse" aria-hidden>{{ help_text }}</span>
+{% endif %}
 {% endmacro %}
 
 {% macro select(label, name, options, help_text=None, required=False, form_data={}) %}
 <label>{{ label }}</label>
+<div class="input-wrapper">
 <select class="form-control {{ name }}-field" name="{{ name }}"{% if required %} required {% endif %}>
   {% for option, option_label in options.items() %}
   <option value="{{ option }}" {% if option == form_data.get(name)  %} selected="selected"{% endif %}>{{ option_label }}</option>
   {% endfor %}
 </select>
-{% if help_text is not none %}<span class="help-text text-muted help-text-top">{{ help_text }}</span>{% endif %}
+</div>
+{% if help_text is not none %}
+{{ help_button(name) }}
+<span class="help-text text-muted {{ name }}-help-text collapse">{{ help_text }}</span>
+{% endif %}
 {% endmacro %}
 
 {% macro radio(label, name, options, help_text=None, required=False, form_data={}) %}
 <label>{{ label }}</label><br/>
+<div class="input-wrapper">
 {% for option, option_label in options.items() %}
 <input name="{{ name }}" type="radio" class="{{ name }}-field" value="{{ option }}">{{ option_label }}</label>
 {% endfor %}
-{% if help_text is not none %}<span class="help-text text-muted">{{ help_text }}</span>{% endif %}
+</div>
+{% if help_text is not none %}
+{{ help_button(name) }}
+<span class="help-text text-muted {{ name }}-help-text collapse">{{ help_text }}</span>
+{% endif %}
 {% endmacro %}
 
 {% macro timedelta(label, name, help_text=None, form_data={}) %}
   <label>{{ label }}</label><br/>
+  <div class="input-wrapper">
   <input type="number" name="{{ name }}_number" step="1" min="0" {% if name+'_number' in form_data %}value="{{ form_data[name+'_number'] }}"{% endif %} required class="form-control time-field {{name }}-field">
   <select required name="{{ name }}_units" class="form-control time-field">
     <option value="minutes">Minutes</option>
     <option value="hours">Hours</option>
     <option value="days">Days</option>
   </select>
-{% if help_text is not none %}<span class="help-text text-muted  time-field-help help-text-top">{{ help_text }}</span>{% endif %}
+  </div>
+{% if help_text is not none %}
+{{ help_button(name) }}
+<span class="help-text text-muted  time-field-help {{ name }}-help-text collapse">{{ help_text }}</span>
+{% endif %}
 {% endmacro %}
 
 {% macro time_of_day(label, name, help_text=None, required=False, form_data={}) %}
 <label>{{ label }}</label><br/>
+<div class="input-wrapper">
 <select {% if required %}required{% endif %} name="{{ name }}_hours" class="form-control time-field {{ name }}_hours-field">
   {% for i in range(0,24) %}
   <option value="{{ i }}">{{ '%02d' % i }}</option>
@@ -56,5 +80,10 @@
   <option value="{{ i }}">{{ '%02d' % i }}</option>
   {% endfor %}
 </select>
-{% if help_text is not none %}<span class="help-text text-muted  time-field-help help-text-top">{{ help_text }}</span>{% endif %}
+UTC
+</div>
+{% if help_text is not none %}
+{{ help_button(name) }}
+<span class="help-text text-muted  time-field-help {{ name }}-help-text collapse">{{ help_text }}</span>
+{% endif %}
 {% endmacro %}

--- a/sfa_dash/templates/forms/observation_download_form.html
+++ b/sfa_dash/templates/forms/observation_download_form.html
@@ -15,12 +15,6 @@
 	  <label for="end">End time:</label>
 	  <input type="datetime-local" id="end" name="period-end">
     </div>
-<div class="form-element">
-      <label>Timezone</label>
-      <select required name="timezone" class="form-control">
-        <option value="utc">UTC</option>
-      </select>
-    </div>
     <div class="form-element full-width">
       <label for="format">Format</label><br/>
       <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>


### PR DESCRIPTION
closes #25 
Removes the automatic focus-triggered tooltips and adds question mark button triggers as shown below: 
![manual_tooltips](https://user-images.githubusercontent.com/21206164/55841024-71363f00-5ae2-11e9-897e-b5e6acc07f6a.png)
