### PR TITLE
Tooltip display OS compatibility

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -233,5 +233,5 @@ a.help-button{
 }
 .input-wrapper{
     width: calc(100% - 29px);
-    display: inline-block;
+    display: inline-flex;
 }

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -232,6 +232,6 @@ a.help-button{
     display: inline-block;
 }
 .input-wrapper{
-    width: calc(100% - 28px);
+    width: calc(100% - 29px);
     display: inline-block;
 }

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -192,6 +192,8 @@ span.help-text{
   background-color: white;
   box-shadow: 1px 1px 1px;
   z-index: 1;
+  left: 0;
+  top: 100%;
 }
 /* Tooltip arrow */
 span.help-text::before {
@@ -225,6 +227,9 @@ a.help-button{
     width: 24px;
     display: inline-block;
     text-align: center;
+}
+.form-control{
+    display: inline-block;
 }
 .input-wrapper{
     width: calc(100% - 28px);

--- a/sfa_dash/templates/forms/cdf_forecast_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_form.html
@@ -62,8 +62,11 @@
     </div>
     <div class="form-element">
         <label>Constant Values</label>
+        <div class="input-wrapper">
         <input type="text" name="constant_values" class="form-control constant_values-field" pattern="((\d+)(\.\d+)?)(,\s*\d+(\.\d+)?)*">
-        <span class="help-text text-muted  constant_values-help">A comma-separated list of variable values or percentiles for the set of forecasts in the probabilistic forecast. Each value can be a non-negative float or integer. e.g. "5.0,20.0,50.0,80.0,95.0"</span>
+        </div>
+        {{ form.help_button('constant_values') }}
+        <span class="help-text text-muted  constant_values-help-text collapse">A comma-separated list of variable values or percentiles for the set of forecasts in the probabilistic forecast. Each value can be a non-negative float or integer. e.g. "5.0,20.0,50.0,80.0,95.0"</span>
     </div>
     <div class="form-element">
       

--- a/sfa_dash/templates/forms/site_form.html
+++ b/sfa_dash/templates/forms/site_form.html
@@ -106,7 +106,8 @@
 	        <label>Backtrack</label>
             <input type='radio' name="backtrack" value="true" class="backtrack-field" checked/>True
             <input type='radio' name="backtrack" value="false" class="backtrack-field"/>False
-		    <span class="help-text">Indicator of if a tracking system uses backtracking.</span>
+            {{ form.help_button('backtrack') }}
+		    <span class="help-text backtrack-help-text collapse">Indicator of if a tracking system uses backtracking.</span>
 	      </div>
         </div>
 	  </fieldset>


### PR DESCRIPTION
Intends to close #36 
I wasn't able to replicate the issue exactly, but the changes in this pull request brought the behavior and appearance of the forms inline across browsers.

also fixes a couple other issues found on 
- Aligns tooltips with the center of the input element. 
- Explicity set `display` property to inline-block for nested input elements.
- add help (?) button to constant_values and backtrack fields.