### PR TITLE
Delete

### DIFF
--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -50,3 +50,20 @@ def post_request(path, payload, json=True):
                   'data': payload}
     return oauth_request_session.post(
         f'{app.config["SFA_API_URL"]}{path}', **kwargs)
+
+
+def delete_request(path, **kwargs):
+    """Make a delete request.
+
+    Parameters
+    ----------
+    path: str
+        The api endpoint to post to including leading slash.
+
+    Returns
+    -------
+    requests.Response
+        The api response.
+    """
+    return oauth_request_session.delete(
+        f'{app.config["SFA_API_URL"]}{path}', **kwargs)

--- a/sfa_dash/api_interface/cdf_forecast_groups.py
+++ b/sfa_dash/api_interface/cdf_forecast_groups.py
@@ -1,29 +1,29 @@
-from sfa_dash.api_interface import get_request, post_request
+from sfa_dash.api_interface import get_request, post_request, delete_request
 
 
 def get_metadata(forecast_id):
-    r = get_request(f'/forecasts/cdf/{forecast_id}')
-    return r
+    req = get_request(f'/forecasts/cdf/{forecast_id}')
+    return req
 
 
 def get_values(forecast_id, **kwargs):
-    r = get_request(f'/forecasts/cdf/{forecast_id}/values', **kwargs)
-    return r
+    req = get_request(f'/forecasts/cdf/{forecast_id}/values', **kwargs)
+    return req
 
 
 def list_metadata(site_id=None):
     if site_id is not None:
-        r = get_request(f'/sites/{site_id}/forecasts/cdf')
+        req = get_request(f'/sites/{site_id}/forecasts/cdf')
     else:
-        r = get_request('/forecasts/cdf/')
-    return r
+        req = get_request('/forecasts/cdf/')
+    return req
 
 
 def post_metadata(forecast_dict):
-    r = post_request('/forecasts/cdf/', forecast_dict)
-    return r
+    req = post_request('/forecasts/cdf/', forecast_dict)
+    return req
 
 
-def post_values(uuid, values, json=True):
-    r = post_request(f'/forecasts/cdf/single/{uuid}/values', values, json)
-    return r
+def delete(forecast_id):
+    req = delete_request(f'/forecasts/cdf/{forecast_id}')
+    return req

--- a/sfa_dash/api_interface/cdf_forecasts.py
+++ b/sfa_dash/api_interface/cdf_forecasts.py
@@ -2,15 +2,15 @@ from sfa_dash.api_interface import get_request, post_request
 
 
 def get_metadata(forecast_id):
-    r = get_request(f'/forecasts/cdf/single/{forecast_id}')
-    return r
+    req = get_request(f'/forecasts/cdf/single/{forecast_id}')
+    return req
 
 
 def get_values(forecast_id, **kwargs):
-    r = get_request(f'/forecasts/cdf/single/{forecast_id}/values', **kwargs)
-    return r
+    req = get_request(f'/forecasts/cdf/single/{forecast_id}/values', **kwargs)
+    return req
 
 
 def post_values(uuid, values, json=True):
-    r = post_request(f'/forecasts/cdf/single/{uuid}/values', values, json)
-    return r
+    req = post_request(f'/forecasts/cdf/single/{uuid}/values', values, json)
+    return req

--- a/sfa_dash/api_interface/forecasts.py
+++ b/sfa_dash/api_interface/forecasts.py
@@ -1,29 +1,34 @@
-from sfa_dash.api_interface import get_request, post_request
+from sfa_dash.api_interface import get_request, post_request, delete_request
 
 
 def get_metadata(forecast_id):
-    r = get_request(f'/forecasts/single/{forecast_id}/metadata')
-    return r
+    req = get_request(f'/forecasts/single/{forecast_id}/metadata')
+    return req
 
 
 def get_values(forecast_id, **kwargs):
-    r = get_request(f'/forecasts/single/{forecast_id}/values', **kwargs)
-    return r
+    req = get_request(f'/forecasts/single/{forecast_id}/values', **kwargs)
+    return req
 
 
 def list_metadata(site_id=None):
     if site_id is not None:
-        r = get_request(f'/sites/{site_id}/forecasts/single')
+        req = get_request(f'/sites/{site_id}/forecasts/single')
     else:
-        r = get_request('/forecasts/single/')
-    return r
+        req = get_request('/forecasts/single/')
+    return req
 
 
 def post_metadata(forecast_dict):
-    r = post_request('/forecasts/single/', forecast_dict)
-    return r
+    req = post_request('/forecasts/single/', forecast_dict)
+    return req
 
 
 def post_values(uuid, values, json=True):
-    r = post_request(f'/forecasts/single/{uuid}/values', values, json)
-    return r
+    req = post_request(f'/forecasts/single/{uuid}/values', values, json)
+    return req
+
+
+def delete(forecast_id):
+    req = delete_request(f'/forecasts/single/{forecast_id}')
+    return req

--- a/sfa_dash/api_interface/observations.py
+++ b/sfa_dash/api_interface/observations.py
@@ -1,29 +1,33 @@
-from sfa_dash.api_interface import get_request, post_request
+from sfa_dash.api_interface import get_request, post_request, delete_request
 
 
 def get_metadata(observation_id):
-    r = get_request(f'/observations/{observation_id}/metadata')
-    return r
+    req = get_request(f'/observations/{observation_id}/metadata')
+    return req
 
 
 def get_values(observation_id, **kwargs):
-    r = get_request(f'/observations/{observation_id}/values', **kwargs)
-    return r
+    req = get_request(f'/observations/{observation_id}/values', **kwargs)
+    return req
 
 
 def list_metadata(site_id=None):
     if site_id is not None:
-        r = get_request(f'/sites/{site_id}/observations')
+        req = get_request(f'/sites/{site_id}/observations')
     else:
-        r = get_request('/observations/')
-    return r
+        req = get_request('/observations/')
+    return req
 
 
 def post_metadata(obs_dict):
-    r = post_request('/observations/', obs_dict)
-    return r
+    req = post_request('/observations/', obs_dict)
+    return req
 
 
 def post_values(uuid, values, json=True):
-    r = post_request(f'/observations/{uuid}/values', values, json)
-    return r
+    req = post_request(f'/observations/{uuid}/values', values, json)
+    return req
+
+def delete(observation_id):
+    req = delete_request(f'/observation/{uuid}')
+    return req

--- a/sfa_dash/api_interface/observations.py
+++ b/sfa_dash/api_interface/observations.py
@@ -28,6 +28,7 @@ def post_values(uuid, values, json=True):
     req = post_request(f'/observations/{uuid}/values', values, json)
     return req
 
+
 def delete(observation_id):
     req = delete_request(f'/observations/{observation_id}')
     return req

--- a/sfa_dash/api_interface/observations.py
+++ b/sfa_dash/api_interface/observations.py
@@ -29,5 +29,5 @@ def post_values(uuid, values, json=True):
     return req
 
 def delete(observation_id):
-    req = delete_request(f'/observation/{uuid}')
+    req = delete_request(f'/observations/{observation_id}')
     return req

--- a/sfa_dash/api_interface/sites.py
+++ b/sfa_dash/api_interface/sites.py
@@ -17,6 +17,7 @@ def post_metadata(site_dict):
     r = post_request('/sites/', site_dict, json=True)
     return r
 
+
 def delete(site_id):
     req = delete_request(f'/sites/{site_id}')
     return req

--- a/sfa_dash/api_interface/sites.py
+++ b/sfa_dash/api_interface/sites.py
@@ -1,6 +1,6 @@
 """Helper functions for all Solar Forecast Arbiter /sites/* endpoints.
 """
-from sfa_dash.api_interface import get_request, post_request
+from sfa_dash.api_interface import get_request, post_request, delete_request
 
 
 def list_metadata():
@@ -16,3 +16,7 @@ def get_metadata(site_id):
 def post_metadata(site_dict):
     r = post_request('/sites/', site_dict, json=True)
     return r
+
+def delete(site_id):
+    req = delete_request(f'/sites/{site_id}')
+    return req

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -41,7 +41,7 @@ class SiteDashView(BaseView):
                                      site_id=self.metadata['site_id']),
             'observations_url': url_for('data_dashboard.observations',
                                         site_id=self.metadata['site_id']),
-            'cdf_forecasts_url': url_for('data_dashboard.cdf_forecasts',
+            'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
                                          site_id=self.metadata['site_id'])
         }
         temp_args['subnav'] = self.format_subnav(**subnav_kwargs)

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -21,7 +21,7 @@ class DataListingView(BaseView):
             self.table_function = DataTables.get_forecast_table
         elif data_type == 'observation':
             self.table_function = DataTables.get_observation_table
-        elif data_type == 'cdf_forecast':
+        elif data_type == 'cdf_forecast_group':
             self.table_function = DataTables.get_cdf_forecast_table
         else:
             raise Exception
@@ -30,7 +30,7 @@ class DataListingView(BaseView):
     def breadcrumb_html(self, site_id=None, organization=None, **kwargs):
         breadcrumb_format = '/<a href="{url}">{text}</a>'
         breadcrumb = ''
-        if self.data_type == 'cdf_forecast':
+        if self.data_type == 'cdf_forecast_group':
             type_label = 'CDF Forecast'
         else:
             type_label = self.data_type.title()
@@ -40,7 +40,7 @@ class DataListingView(BaseView):
                 abort(404)
             site_metadata = site_metadata_request.json()
             breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.sites_view'),
+                url=url_for('data_dashboard.sites'),
                 text='Sites')
             breadcrumb += breadcrumb_format.format(
                 url=url_for('data_dashboard.site_view', uuid=site_id),
@@ -59,7 +59,7 @@ class DataListingView(BaseView):
                                         **kwargs),
             'forecasts_url': url_for('data_dashboard.forecasts',
                                      **kwargs),
-            'cdf_forecasts_url': url_for('data_dashboard.cdf_forecasts',
+            'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
                                          **kwargs)
         }
         template_args['subnav'] = self.format_subnav(**subnav_kwargs)

--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -1,0 +1,52 @@
+from flask import url_for, render_template, abort, redirect
+
+from sfa_dash.api_interface import sites, observations, forecasts, cdf_forecast_groups
+from sfa_dash.blueprints.base import BaseView
+from sfa_dash.blueprints.dash import DataDashView
+
+
+class DeleteConfirmation(DataDashView):
+    def __init__(self, data_type):
+        if data_type == 'forecast':
+            self.api_handle = forecasts
+            self.metadata_template = 'data/metadata/forecast_metadata.html'
+        elif data_type == 'observation':
+            self.api_handle = observations
+            self.metadata_template = 'data/metadata/observation_metadata.html'
+        elif data_type == 'cdf_forecast_group':
+            self.api_handle = cdf_forecast_groups
+            self.metadata_template = 'data/metadata/cdf_forecast_group_metadata.html'
+        elif data_type == 'site':
+            self.api_handle = sites
+            self.metadata_template = 'data/metadata/site_metadata.html'
+        else:
+            raise ValueError(f'No Deletetion Form defined for {data_type}.')
+        self.data_type = data_type
+        self.template = 'forms/deletion_form.html'
+        
+
+    def template_args(self, **kwargs):
+        temp_args = {
+            'metadata': render_template(self.metadata_template, **self.metadata),
+            'site_metadata': self.metadata['site'],
+            'uuid': self.metadata['uuid'],
+            'data_type': self.data_type,
+        }
+        return temp_args
+
+    def get(self, uuid):
+        """Presents a delete confirmation to the user"""
+        metadata_request = self.api_handle.get_metadata(uuid)
+        if metadata_request.status_code != 200:
+            abort(404)
+        self.metadata = metadata_request.json()
+        self.metadata['uuid'] = uuid
+        self.metadata['site'] = self.get_site_metadata(self.metadata['site_id'])
+        return render_template(self.template, **self.template_args(**self.metadata))
+
+
+    def post(self, uuid):
+        delete_request = self.api_handle.delete(uuid)
+        if delete_request.status_code != 204:
+            abort(404)
+        return redirect(url_for(f'data_dashboard.{self.data_type}s'))

--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -61,7 +61,9 @@ class DeleteConfirmation(DataDashView):
             # the confirmation page, redirect to confirm.
             return redirect(confirmation_url)
         delete_request = self.api_handle.delete(uuid)
-        if delete_request.status_code == 400:
+        if delete_request.status_code == 204:
+            return redirect(url_for(f'data_dashboard.{self.data_type}s'))
+        elif delete_request.status_code == 400:
             # Redirect and display errors if the delete request
             # failed
             response_json = delete_request.json()
@@ -69,4 +71,6 @@ class DeleteConfirmation(DataDashView):
             return self.get(uuid, errors=errors)
         elif delete_request.status_code == 404:
             abort(404)
-        return redirect(url_for(f'data_dashboard.{self.data_type}s'))
+        else:
+            errors = {"error": ["Could not complete the requested action."]}
+            return self.get(uuid, errors=errors)

--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -1,7 +1,7 @@
 from flask import url_for, render_template, abort, redirect
 
-from sfa_dash.api_interface import sites, observations, forecasts, cdf_forecast_groups
-from sfa_dash.blueprints.base import BaseView
+from sfa_dash.api_interface import (sites, observations, forecasts,
+                                    cdf_forecast_groups)
 from sfa_dash.blueprints.dash import DataDashView
 
 
@@ -15,7 +15,7 @@ class DeleteConfirmation(DataDashView):
             self.metadata_template = 'data/metadata/observation_metadata.html'
         elif data_type == 'cdf_forecast_group':
             self.api_handle = cdf_forecast_groups
-            self.metadata_template = 'data/metadata/cdf_forecast_group_metadata.html'
+            self.metadata_template = 'data/metadata/cdf_forecast_group_metadata.html' # NOQA
         elif data_type == 'site':
             self.api_handle = sites
             self.metadata_template = 'data/metadata/site_metadata.html'
@@ -23,11 +23,11 @@ class DeleteConfirmation(DataDashView):
             raise ValueError(f'No Deletetion Form defined for {data_type}.')
         self.data_type = data_type
         self.template = 'forms/deletion_form.html'
-        
 
     def template_args(self, **kwargs):
         temp_args = {
-            'metadata': render_template(self.metadata_template, **self.metadata),
+            'metadata': render_template(self.metadata_template,
+                                        **self.metadata),
             'site_metadata': self.metadata['site'],
             'uuid': self.metadata['uuid'],
             'data_type': self.data_type,
@@ -41,9 +41,11 @@ class DeleteConfirmation(DataDashView):
             abort(404)
         self.metadata = metadata_request.json()
         self.metadata['uuid'] = uuid
-        self.metadata['site'] = self.get_site_metadata(self.metadata['site_id'])
-        return render_template(self.template, **self.template_args(**self.metadata))
-
+        self.metadata['site'] = self.get_site_metadata(
+            self.metadata['site_id'])
+        return render_template(
+            self.template,
+            **self.template_args(**self.metadata))
 
     def post(self, uuid):
         delete_request = self.api_handle.delete(uuid)

--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -47,6 +47,7 @@ class DeleteConfirmation(DataDashView):
         self.metadata['uuid'] = uuid
         self.metadata['site'] = self.get_site_metadata(
             self.metadata['site_id'])
+        self.metadata['site_link'] = self.generate_site_link(self.metadata)
         return render_template(
             self.template,
             **self.template_args(**kwargs))

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -19,8 +19,8 @@ class MetadataForm(BaseView):
             self.api_handle = forecasts
             self.formatter = self.forecast_formatter
             self.metadata_template = 'data/metadata/site_metadata.html'
-        elif data_type == 'cdf_forecast':
-            self.template = 'forms/cdf_forecast_form.html'
+        elif data_type == 'cdf_forecast_group':
+            self.template = 'forms/cdf_forecast_group_form.html'
             self.id_key = 'forecast_id'
             self.api_handle = cdf_forecast_groups
             self.formatter = self.cdf_forecast_formatter
@@ -237,7 +237,6 @@ class CreateForm(MetadataForm):
             template_args['site_metadata'] = site_metadata
             template_args['metadata'] = self.render_metadata_section(
                 site_metadata)
-
         if response.status_code == 201:
             uuid = response.text
             return redirect(url_for(f'data_dashboard.{self.data_type}_view',
@@ -402,8 +401,9 @@ forms_blp.add_url_rule('/sites/<site_id>/forecasts/single/create',
                        view_func=CreateForm.as_view('create_site_forecast',
                                                     data_type='forecast'))
 forms_blp.add_url_rule('/sites/<site_id>/forecasts/cdf/create',
-                       view_func=CreateForm.as_view('create_cdf_forecast',
-                                                    data_type='cdf_forecast'))
+                       view_func=CreateForm.as_view(
+                           'create_cdf_forecast_group',
+                           data_type='cdf_forecast_group'))
 forms_blp.add_url_rule('/observations/<uuid>/upload',
                        view_func=UploadForm.as_view('upload_observation_data',
                                                     data_type='observation'))

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -1,6 +1,7 @@
 from sfa_dash.blueprints.dash import DataDashView
 from sfa_dash.blueprints.data_listing import DataListingView
 from sfa_dash.blueprints.sites import SingleSiteView, SitesListingView
+from sfa_dash.blueprints.delete import DeleteConfirmation
 from sfa_dash.api_interface import (observations, forecasts,
                                     cdf_forecasts, cdf_forecast_groups)
 from flask import (Blueprint, render_template,
@@ -14,7 +15,7 @@ class SingleObservationView(DataDashView):
         breadcrumb_format = '/<a href="{url}">{text}</a>'
         breadcrumb = ''
         breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites_view'),
+            url=url_for('data_dashboard.sites'),
             text='Sites')
         breadcrumb += breadcrumb_format.format(
             url=url_for('data_dashboard.site_view',
@@ -48,6 +49,9 @@ class SingleObservationView(DataDashView):
         temp_args['download_link'] = url_for(
             'forms.download_observation_data',
             uuid=uuid)
+        temp_args['delete_link'] = url_for(
+            f'data_dashboard.delete_observation',
+            uuid=uuid)
         return render_template(self.template, **temp_args)
 
 
@@ -58,14 +62,14 @@ class SingleCDFForecastView(DataDashView):
         breadcrumb_format = '/<a href="{url}">{text}</a>'
         breadcrumb = ''
         breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites_view'),
+            url=url_for('data_dashboard.sites'),
             text='Sites')
         breadcrumb += breadcrumb_format.format(
             url=url_for('data_dashboard.site_view',
                         uuid=self.metadata['site_id']),
             text=self.metadata['site']['name'])
         breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecasts',
+            url=url_for('data_dashboard.cdf_forecast_groups',
                         uuid=self.metadata['site_id']),
             text='CDF Forecasts')
         breadcrumb += breadcrumb_format.format(
@@ -76,7 +80,6 @@ class SingleCDFForecastView(DataDashView):
             url=url_for('data_dashboard.cdf_forecast_view',
                         uuid=self.metadata['forecast_id']),
             text=self.metadata['constant_value'])
-
         return breadcrumb
 
     def get(self, uuid, **kwargs):
@@ -107,7 +110,7 @@ class SingleForecastView(DataDashView):
         breadcrumb_format = '/<a href="{url}">{text}</a>'
         breadcrumb = ''
         breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites_view'),
+            url=url_for('data_dashboard.sites'),
             text='Sites')
         breadcrumb += breadcrumb_format.format(
             url=url_for('data_dashboard.site_view',
@@ -141,6 +144,9 @@ class SingleForecastView(DataDashView):
         temp_args['download_link'] = url_for(
             'forms.download_forecast_data',
             uuid=uuid)
+        temp_args['delete_link'] = url_for(
+            f'data_dashboard.delete_forecast',
+            uuid=uuid)
         return render_template(self.template, **temp_args)
 
 
@@ -151,14 +157,14 @@ class SingleCDFForecastGroupView(DataDashView):
         breadcrumb_format = '/<a href="{url}">{text}</a>'
         breadcrumb = ''
         breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites_view'),
+            url=url_for('data_dashboard.sites'),
             text='Sites')
         breadcrumb += breadcrumb_format.format(
             url=url_for('data_dashboard.site_view',
                         uuid=self.metadata['site_id']),
             text=self.metadata['site']['name'])
         breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecasts',
+            url=url_for('data_dashboard.cdf_forecast_groups',
                         site_id=self.metadata['site_id']),
             text='CDF Forecasts')
         breadcrumb += breadcrumb_format.format(
@@ -180,6 +186,9 @@ class SingleCDFForecastGroupView(DataDashView):
         temp_args['metadata_section'] = render_template(
             'data/metadata/cdf_forecast_group_metadata.html',
             **self.metadata)
+        temp_args['delete_link'] = url_for(
+            f'data_dashboard.delete_cdf_forecast_group',
+            uuid=uuid)
         return render_template(self.template, **temp_args)
 
 
@@ -198,7 +207,7 @@ class TrialsView(DataDashView):
 data_dash_blp = Blueprint('data_dashboard', 'data_dashboard')
 data_dash_blp.add_url_rule(
     '/sites/',
-    view_func=SitesListingView.as_view('sites_view'))
+    view_func=SitesListingView.as_view('sites'))
 data_dash_blp.add_url_rule(
     '/sites/<uuid>/',
     view_func=SingleSiteView.as_view('site_view'))
@@ -222,8 +231,8 @@ data_dash_blp.add_url_rule(
     view_func=DataListingView.as_view('forecasts', data_type='forecast'))
 data_dash_blp.add_url_rule(
     '/forecasts/cdf/',
-    view_func=DataListingView.as_view('cdf_forecasts',
-                                      data_type='cdf_forecast'))
+    view_func=DataListingView.as_view('cdf_forecast_groups',
+                                      data_type='cdf_forecast_group'))
 data_dash_blp.add_url_rule(
     '/forecasts/single/<uuid>',
     view_func=SingleForecastView.as_view('forecast_view'))
@@ -233,3 +242,16 @@ data_dash_blp.add_url_rule(
 data_dash_blp.add_url_rule(
     '/forecasts/cdf/single/<uuid>',
     view_func=SingleCDFForecastView.as_view('cdf_forecast_view'))
+
+data_dash_blp.add_url_rule(
+    '/sites/<uuid>/delete',
+    view_func=DeleteConfirmation.as_view('delete_site', data_type='site'))
+data_dash_blp.add_url_rule(
+    '/observations/<uuid>/delete',
+    view_func=DeleteConfirmation.as_view('delete_observation', data_type='observation'))
+data_dash_blp.add_url_rule(
+    '/forecasts/single/<uuid>/delete',
+    view_func=DeleteConfirmation.as_view('delete_forecast', data_type='forecast'))
+data_dash_blp.add_url_rule(
+    '/forecasts/cdf/<uuid>/delete',
+    view_func=DeleteConfirmation.as_view('delete_cdf_forecast_group', data_type='cdf_forecast_group'))

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -248,10 +248,13 @@ data_dash_blp.add_url_rule(
     view_func=DeleteConfirmation.as_view('delete_site', data_type='site'))
 data_dash_blp.add_url_rule(
     '/observations/<uuid>/delete',
-    view_func=DeleteConfirmation.as_view('delete_observation', data_type='observation'))
+    view_func=DeleteConfirmation.as_view(
+        'delete_observation', data_type='observation'))
 data_dash_blp.add_url_rule(
     '/forecasts/single/<uuid>/delete',
-    view_func=DeleteConfirmation.as_view('delete_forecast', data_type='forecast'))
+    view_func=DeleteConfirmation.as_view(
+        'delete_forecast', data_type='forecast'))
 data_dash_blp.add_url_rule(
     '/forecasts/cdf/<uuid>/delete',
-    view_func=DeleteConfirmation.as_view('delete_cdf_forecast_group', data_type='cdf_forecast_group'))
+    view_func=DeleteConfirmation.as_view(
+        'delete_cdf_forecast_group', data_type='cdf_forecast_group'))

--- a/sfa_dash/blueprints/sites.py
+++ b/sfa_dash/blueprints/sites.py
@@ -10,7 +10,7 @@ class SitesListingView(SiteDashView):
     def breadcrumb_html(self, site=None, **kwargs):
         breadcrumb_format = '/<a href="{url}">{text}</a>'
         breadcrumb = breadcrumb_format.format(
-            url=url_for('data_dashboard.sites_view'),
+            url=url_for('data_dashboard.sites'),
             text='Sites')
         return breadcrumb
 
@@ -35,7 +35,7 @@ class SingleSiteView(SiteDashView):
         bc_format = '/<a href="{url}">{text}</a>'
         bc = ''
         bc += bc_format.format(
-            url=url_for('data_dashboard.sites_view'),
+            url=url_for('data_dashboard.sites'),
             text="Sites")
         bc += bc_format.format(
             url=url_for('data_dashboard.site_view',

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -7,6 +7,9 @@
 {% if download_link is defined %}
 <a role="button" class="btn btn-primary btn-sm" href="{{download_link}}">Download data</a>
 {% endif %}
+{% if delete_link is defined %}
+<a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
+{% endif %}
 <div class="row data-plots-wrapper">
     <!-- PLOTS -->
 </div>

--- a/sfa_dash/templates/data/cdf_forecast.html
+++ b/sfa_dash/templates/data/cdf_forecast.html
@@ -7,6 +7,9 @@
 {% if download_link is defined %}
 <a role="button" class="btn btn-primary btn-sm" href="{{download_link}}">Download data</a>
 {% endif %}
+{% if delete_link is defined %}
+<a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
+{% endif %}
 {% if 'constant_values' in metadata %}
 <div class="bin-list">
   <table>

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -5,7 +5,8 @@
 {% block toolbar %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site_observation', site_id=site_id) }}">Create new Observation</a>
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site_forecast', site_id=site_id) }}">Create new Forecast</a>
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast', site_id=site_id) }}">Create new Probabilistic Forecast</a>
+  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', site_id=site_id) }}">Create new Probabilistic Forecast</a>
+  <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
 
 {% endblock %}
 {{ listing | safe }}

--- a/sfa_dash/templates/data/table/cdf_forecast_table.html
+++ b/sfa_dash/templates/data/table/cdf_forecast_table.html
@@ -2,7 +2,7 @@
 {% block tools %}
 <input type="text" placeholder="Search" class="search">
 {% if site_id is defined %}
-<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast', site_id=site_id)}}">Create new Probabilistic Forecast</a>
+<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', site_id=site_id)}}">Create new Probabilistic Forecast</a>
 {% endif %}
 {% endblock %}
 {% import "data/table/forecast_macro.jinja" as table_macro %}

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -7,7 +7,7 @@
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
-<form action="{{ url_for('forms.create_cdf_forecast', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
+<form action="{{ url_for('forms.create_cdf_forecast_group', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
   <div class="form-group">
     <input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
 	<div class="form-element">

--- a/sfa_dash/templates/forms/deletion_form.html
+++ b/sfa_dash/templates/forms/deletion_form.html
@@ -1,0 +1,12 @@
+{% extends "dash/data.html" %}
+{% import "forms/form_macros.jinja" as form %}
+{% set page_title = 'Delete ' + data_type %}
+{% block content %}
+{{ metadata | safe }}
+{% include "sections/notifications.html" %}
+<form action="{{ url_for('data_dashboard.delete_'+data_type, uuid=uuid) }}" method="post" id="delete-form", enctype='application/json'>
+  <p>Are you sure you want to delete this resource? This action is irreversible.</p>
+  <button type="submit" form="delete-form" value="Submit" class="btn btn-primary">Yes</button>
+  <a href="{{ url_for('data_dashboard.' + data_type + '_view', uuid=uuid) }}" class="btn btn-primary">No</a>
+</form>
+{% endblock %}

--- a/sfa_dash/templates/forms/deletion_form.html
+++ b/sfa_dash/templates/forms/deletion_form.html
@@ -6,7 +6,7 @@
 {% include "sections/notifications.html" %}
 <form action="{{ url_for('data_dashboard.delete_'+data_type, uuid=uuid) }}" method="post" id="delete-form", enctype='application/json'>
   <p>Are you sure you want to delete this resource? This action is irreversible.</p>
-  <button type="submit" form="delete-form" value="Submit" class="btn btn-primary">Yes</button>
+  <button type="submit" form="delete-form" value="Submit" class="btn btn-danger btn-sml">Yes</button>
   <a href="{{ url_for('data_dashboard.' + data_type + '_view', uuid=uuid) }}" class="btn btn-primary">No</a>
 </form>
 {% endblock %}

--- a/sfa_dash/templates/sidebar.html
+++ b/sfa_dash/templates/sidebar.html
@@ -1,8 +1,8 @@
 <div class="col-sm-3 col-xs-12 sidebar-wrapper mt-3 border-right">
   <ul class="sidebaru-menu menu-list">
-    <li class="py-1"><a href="{{ url_for('data_dashboard.sites_view') }}">Sites</a></li>
+    <li class="py-1"><a href="{{ url_for('data_dashboard.sites') }}">Sites</a></li>
     <li class="py-1"><a href="{{ url_for('data_dashboard.observations') }}">Observations</a></li>
     <li class="py-1"><a href="{{ url_for('data_dashboard.forecasts') }}">Forecasts</a></li>
-    <li class="py-1"><a href="{{ url_for('data_dashboard.cdf_forecasts') }}">Probabilistic Forecasts</a></li>
+    <li class="py-1"><a href="{{ url_for('data_dashboard.cdf_forecast_groups') }}">Probabilistic Forecasts</a></li>
   </ul>
 </div>


### PR DESCRIPTION
closes #19 
This PR adds a delete button on metadata pages and a confirmation page warning the user that they cannot undo a deletion. 
The post endpoint accepts the delete request and either redirects to the appropriate listing page on success, or redirects to the confirmation with a list of errors.