### PR TITLE
csrf protection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==1.0.2
+Flask-SeaSurf==0.2.2
 requests==2.21.0
 pandas==0.24.2
 flask-dance

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -1,4 +1,5 @@
 from flask import Flask, redirect, url_for, render_template, session, request
+from flask_seasurf import SeaSurf
 
 
 from sfa_dash.blueprints.auth0 import (make_auth0_blueprint, logout,
@@ -12,6 +13,7 @@ def create_app(config=None):
     config = config or 'sfa_dash.config.DevConfig'
     app.config.from_object(config)
     app.secret_key = app.config['SECRET_KEY']
+    SeaSurf(app)
     register_jinja_filters(app)
 
     auth0_bp = make_auth0_blueprint(

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -395,10 +395,10 @@ forms_blp.add_url_rule('/sites/create',
                        view_func=CreateForm.as_view('create_site',
                                                     data_type='site'))
 forms_blp.add_url_rule('/sites/<site_id>/observations/create',
-                       view_func=CreateForm.as_view('create_site_observation',
+                       view_func=CreateForm.as_view('create_observation',
                                                     data_type='observation'))
 forms_blp.add_url_rule('/sites/<site_id>/forecasts/single/create',
-                       view_func=CreateForm.as_view('create_site_forecast',
+                       view_func=CreateForm.as_view('create_forecast',
                                                     data_type='forecast'))
 forms_blp.add_url_rule('/sites/<site_id>/forecasts/cdf/create',
                        view_func=CreateForm.as_view(

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -3,8 +3,8 @@
 {% block content %}
 {{ metadata | safe }}
 {% block toolbar %}
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site_observation', site_id=site_id) }}">Create new Observation</a>
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site_forecast', site_id=site_id) }}">Create new Forecast</a>
+  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', site_id=site_id) }}">Create new Observation</a>
+  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', site_id=site_id) }}">Create new Forecast</a>
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', site_id=site_id) }}">Create new Probabilistic Forecast</a>
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
 

--- a/sfa_dash/templates/data/table/forecast_table.html
+++ b/sfa_dash/templates/data/table/forecast_table.html
@@ -2,7 +2,7 @@
 {% block tools %}
 <input type="text" placeholder="Search" class="search">
 {% if site_id is defined %}
-<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site_forecast', site_id=site_id)}}">Create new Forecast</a>
+<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', site_id=site_id)}}">Create new Forecast</a>
 {% endif %}
 {% endblock %}
 {% import "data/table/forecast_macro.jinja" as table_macro %}

--- a/sfa_dash/templates/data/table/observation_table.html
+++ b/sfa_dash/templates/data/table/observation_table.html
@@ -2,7 +2,7 @@
 {% block tools %}
 <input type="text" placeholder="Search" class="search">
 {% if site_id is defined %}
-<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site_observation', site_id=site_id)}}">Create new Observation</a>
+<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', site_id=site_id)}}">Create new Observation</a>
 {% endif %}
 {% endblock %}
 {% import "data/table/observation_macro.jinja" as table_macro %}

--- a/sfa_dash/templates/forms/base/creation_form.html
+++ b/sfa_dash/templates/forms/base/creation_form.html
@@ -1,12 +1,14 @@
+{% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
-<form action="{{ url_for('forms.create_' + data_type, site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="{{ data_type }}-form">
+{% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
+<form action="{{ url_for('forms.create_' + data_type, site_id=site_metadata['site_id']) }}" method="post" enctype='{{ form_enc }}' id="{{ data_type }}-form">
   <div class="form-group">
     {% block fields %}
     {% endblock %}
-    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+    {{ form.token() }}
   </div>
 </form>
 <button type="submit" form="{{ data_type }}-form" value="Submit" class="btn btn-primary">Submit</button>

--- a/sfa_dash/templates/forms/base/download_form.html
+++ b/sfa_dash/templates/forms/base/download_form.html
@@ -1,0 +1,18 @@
+{% import "forms/form_macros.jinja" as form %}
+{% extends "dash/data.html" %}
+{% block content %}
+{{ metadata | safe }}
+{% include "sections/notifications.html" %}
+{% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
+<form action="{{ url_for('forms.download_' + data_type + '_data', uuid=uuid) }}" method="post"  id="{{ data_type }}-download">
+  <div class="form-group">
+    {% block fields %}
+    {% endblock %}
+    {{ form.token() }}
+  </div>
+</form>
+<div class="form-element">
+  <button type="submit" form="{{ data_type }}-download" value="Submit" class="btn btn-primary">Download</button>
+</div>
+{% endblock %}
+

--- a/sfa_dash/templates/forms/base/upload_form.html
+++ b/sfa_dash/templates/forms/base/upload_form.html
@@ -1,0 +1,21 @@
+{% import "forms/form_macros.jinja" as form %}
+{% extends "dash/data.html" %}
+{% block content %}
+{{ metadata | safe }}
+{% include "sections/notifications.html" %}
+{% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
+<form action="{{ url_for('forms.upload_' + data_type + '_data', uuid=uuid) }}" method="post"  id="{{ data_type }}-upload-form" enctype='multipart/form-data'>
+  <div class="form-group">
+    {% block fields %}
+    {% endblock %}
+    <div class="form-element full-width">
+        <input type="file" name="{{ data_type }}-data" accept=".csv, .json">
+    </div>
+    {{ form.token() }}
+  </div>
+</form>
+<div class="form-element">
+  <button type="submit" form="{{ data_type }}-upload-form" value="Submit" class="btn btn-primary">Upload</button>
+</div>
+{% endblock %}
+

--- a/sfa_dash/templates/forms/base_form.html
+++ b/sfa_dash/templates/forms/base_form.html
@@ -1,0 +1,15 @@
+{% extends "dash/data.html" %}
+{% import "forms/form_macros.jinja" as form %}
+{% block content %}
+{{ metadata | safe }}
+{% include "sections/notifications.html" %}
+{% if form_data is not defined %}
+{% set form_data = {} %}
+{% endif %}
+<form action="{{ url_for('forms.create_cdf_forecast', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
+{% block fields %}
+{% endblock %}
+</form>
+<button type="submit" form="cdf-forecast-form" value="Submit" class="btn btn-primary">Submit</button>
+{% endblock %}
+

--- a/sfa_dash/templates/forms/base_form.html
+++ b/sfa_dash/templates/forms/base_form.html
@@ -1,15 +1,14 @@
 {% extends "dash/data.html" %}
-{% import "forms/form_macros.jinja" as form %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
-{% if form_data is not defined %}
-{% set form_data = {} %}
-{% endif %}
-<form action="{{ url_for('forms.create_cdf_forecast', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
-{% block fields %}
-{% endblock %}
+<form action="{{ url_for('forms.create_' + data_type, site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="{{ data_type }}-form">
+  <div class="form-group">
+    {% block fields %}
+    {% endblock %}
+    <input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+  </div>
 </form>
-<button type="submit" form="cdf-forecast-form" value="Submit" class="btn btn-primary">Submit</button>
+<button type="submit" form="{{ data_type }}-form" value="Submit" class="btn btn-primary">Submit</button>
 {% endblock %}
 

--- a/sfa_dash/templates/forms/cdf_forecast_download_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_download_form.html
@@ -1,43 +1,39 @@
-{% extends "dash/data.html" %}
-{# {% set sidebar = True %} #}
+{% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Forecast data' %}
-{% block content %}
-{{ metadata | safe }}
-<h3>Download data for Forecast 'DA Power'</h3>
-{#<p><b>Available Date Range:</b> <i>2016-01-01T12:00Z</i> to <i>2019-01-01T12:00Z</i></p>#}
-<form action="{{ url_for('forms.download_cdf_forecast_data', uuid=uuid) }}" method="post" id="forecast-download">
-  <div class="form-group">
-	<div class="form-element">
-	  <label for="start">Start time:</label>
-	  <input type="datetime-local" id="start" name="period-start">
-    </div>
-    <div class="form-element">
-	  <label for="end">End time:</label>
-	  <input type="datetime-local" id="end" name="period-end">
-    </div>
-	<div class="form-element full-width">
-	  <label for="format">Format</label><br/>
-	  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
-	  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
-	</div>
-	<div class="form-element full-width">
-	  <div class="download-example csv show">
-	  <p>CSV downloads will have the following format.</p>
-	  <pre class="example-text">
+{% set form_title = "Download data for Forecast 'DA Power'" %}
+{% set data_type = 'cdf_forecast' %}
+{% block fields %}
+<div class="form-element">
+  <label for="start">Start time:</label>
+  <input type="datetime-local" id="start" name="period-start">
+</div>
+<div class="form-element">
+  <label for="end">End time:</label>
+  <input type="datetime-local" id="end" name="period-end">
+</div>
+<div class="form-element full-width">
+  <label for="format">Format</label><br/>
+  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
+  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
+</div>
+<div class="form-element full-width">
+  <div class="download-example csv show">
+  <p>CSV downloads will have the following format.</p>
+  <pre class="example-text">
 # forecast_id: f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1
 # metadata: https://api.solarforecastarbiter.org/forecasts/f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1/metadata
 timestamp,value
 2018-11-22T18:01:00Z,10.23
 2018-11-22T18:02:00Z,10.67
 2018-11-22T18:03:00Z,10.67
-	  </pre>
+  </pre>
 
-	  </div>
-	</div>
-    <div class="form-element full-width">
-	  <div class="download-example json collapse">
-	    <p>JSON downloads will have the following format.</p>
-		<pre class="example-text">{
+  </div>
+</div>
+<div class="form-element full-width">
+  <div class="download-example json collapse">
+    <p>JSON downloads will have the following format.</p>
+	<pre class="example-text">{
     “forecast_id”: “f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1',
     "_links": {
         "metadata": "https://api.solarforecastarbiter.org/forecasts/f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1/metadata",
@@ -57,12 +53,6 @@ timestamp,value
          }
     ] 
 }</pre>
-	  </div>
-	</div>
-
   </div>
-</form>
-<div class="form-element">
-  <button type="submit" form="forecast-download" value="Submit" class="btn btn-primary">Download</button>
 </div>
 {% endblock %}

--- a/sfa_dash/templates/forms/cdf_forecast_download_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_download_form.html
@@ -1,6 +1,5 @@
 {% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Forecast data' %}
-{% set form_title = "Download data for Forecast 'DA Power'" %}
 {% set data_type = 'cdf_forecast' %}
 {% block fields %}
 <div class="form-element">

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -1,88 +1,72 @@
-{# {% extends "dash/data.html" %}
-{% set page_title = 'Create New Probabilistic Forecast' %}
-{% block content %}
-{{ metadata | safe }}
-{% include "sections/notifications.html" %}
-<form action="{{ url_for('forms.create_cdf_forecast', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
-  <div class="form-group">
-
-#}
 {% extends "forms/base_form.html" %}
 {% import "forms/form_macros.jinja" as form %}
+{% set page_title = 'Create CDF Forecast' %}
+{% set data_type = 'cdf_forecast_group' %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
-
 {% block fields %}
-    <input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
-	<div class="form-element">
-      {{ form.input('Name', 'text', 'name', 'Name for the Forecast',
-                    required=True, form_data=form_data) }}
-	</div>
-	<div class="form-element">
-      {{ form.select('Variable', 'variable',
-                     variable_options,
-                     form_data=form_data) }}
-	</div>
-    <div class="form-element">
-      {{ form.time_of_day('Issue time of day', 'issue_time',
-                          'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }}
+<input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
+<div class="form-element">
+  {{ form.input('Name', 'text', 'name', 'Name for the Forecast',
+                required=True, form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.select('Variable', 'variable',
+                 variable_options,
+                 form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.time_of_day('Issue time of day', 'issue_time',
+                      'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }}
+</div>
+<div class="form-element">
+    {{ form.timedelta('Lead time to start', 'lead_time',
+                      'The difference between the issue time and the start of the first forecast interval. Values must be integers.')}}
+</div>
+<div class="form-element">
+  {{ form.timedelta('Run length/Issue frequency', 'run_length',
+                    'The total length of a single issued forecast run. To enforce a continuous, non-overlapping sequence, this is equal to the forecast run issue frequency. Values must be integers.') }}
+</div>
+<div class="form-element">
+  {{ form.timedelta('Interval length', 'interval_length',
+                    'The length of time that each data point represents. Values must be integers.') }}
+</div>
+<div class="form-element">
+  {{ form.select('Interval Label', 'interval_label',
+                 {'beginning': 'Beginning',
+                  'ending': 'Ending',
+                  'instant': 'Instant'},
+                  'Indicates if a time labels the start or the end of an interval.') }}
+</div>
+<div class="form-element">
+  {{ form.select('Interval Value Type', 'interval_value_type',
+                  {"interval_mean": "Mean",
+				   "interval_min": "Min",
+                   "interval_max": "Max",
+                   "interval_median": "Median",
+                   "percentile": "Percentile",
+                   "instantaneous": "Instantaneous"},
+                   form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.radio('Axis', 'axis',
+                {"x": "x: variable value",
+                 "y": "y: percentile"},
+                'The axis on which the constant values of the CDF is specified. The axis can be either x (constant variable values) or y (constant percentiles). The axis is fixed and the same for all forecasts in the probabilistic forecast.',
+                required=True,
+                form_data=form_data)  }}
+</div>
+<div class="form-element">
+    <label>Constant Values</label>
+    <div class="input-wrapper">
+    <input type="text" name="constant_values" class="form-control constant_values-field" pattern="((\d+)(\.\d+)?)(,\s*\d+(\.\d+)?)*">
     </div>
-    <div class="form-element">
-        {{ form.timedelta('Lead time to start', 'lead_time',
-                          'The difference between the issue time and the start of the first forecast interval. Values must be integers.')}}
-	</div>
-	<div class="form-element">
-      {{ form.timedelta('Run length/Issue frequency', 'run_length',
-                        'The total length of a single issued forecast run. To enforce a continuous, non-overlapping sequence, this is equal to the forecast run issue frequency. Values must be integers.') }}
-	</div>
-	<div class="form-element">
-      {{ form.timedelta('Interval length', 'interval_length',
-                        'The length of time that each data point represents. Values must be integers.') }}
-	</div>
-    <div class="form-element">
-      {{ form.select('Interval Label', 'interval_label',
-                     {'beginning': 'Beginning',
-                      'ending': 'Ending',
-                      'instant': 'Instant'},
-                      'Indicates if a time labels the start or the end of an interval.') }}
-    </div>
-    <div class="form-element">
-      {{ form.select('Interval Value Type', 'interval_value_type',
-                      {"interval_mean": "Mean",
-					   "interval_min": "Min",
-                       "interval_max": "Max",
-                       "interval_median": "Median",
-                       "percentile": "Percentile",
-                       "instantaneous": "Instantaneous"},
-                       form_data=form_data) }}
-    </div>
-    <div class="form-element">
-      {{ form.radio('Axis', 'axis', 
-                    {"x": "x: variable value",
-                     "y": "y: percentile"},
-                    'The axis on which the constant values of the CDF is specified. The axis can be either x (constant variable values) or y (constant percentiles). The axis is fixed and the same for all forecasts in the probabilistic forecast.',
-                    required=True,
-                    form_data=form_data)  }}
-    </div>
-    <div class="form-element">
-        <label>Constant Values</label>
-        <div class="input-wrapper">
-        <input type="text" name="constant_values" class="form-control constant_values-field" pattern="((\d+)(\.\d+)?)(,\s*\d+(\.\d+)?)*">
-        </div>
-        {{ form.help_button('constant_values') }}
-        <span class="help-text text-muted  constant_values-help-text collapse">A comma-separated list of variable values or percentiles for the set of forecasts in the probabilistic forecast. Each value can be a non-negative float or integer. e.g. "5.0,20.0,50.0,80.0,95.0"</span>
-    </div>
-    <div class="form-element">
-      
-    </div>
-	<div class="form-element full-width">
-	  <label>Extra Parameters</label>
-      <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
-	</div>
-
- {% endblock %}
- {# </div>
- </form>
-<button type="submit" form="cdf-forecast-form" value="Submit" class="btn btn-primary">Submit</button>
-{% endblock %} #}
+    {{ form.help_button('constant_values') }}
+    <span class="help-text text-muted  constant_values-help-text collapse">A comma-separated list of variable values or percentiles for the set of forecasts in the probabilistic forecast. Each value can be a non-negative float or integer. e.g. "5.0,20.0,50.0,80.0,95.0"</span>
+</div>
+<div class="form-element full-width">
+  <label>Extra Parameters</label>
+  <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
+</div>
+{% endblock %}

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -1,7 +1,7 @@
-{% extends "forms/base_form.html" %}
+{% extends "forms/base/creation_form.html" %}
 {% import "forms/form_macros.jinja" as form %}
 {% set page_title = 'Create CDF Forecast' %}
-{% set data_type = 'cdf_forecast_group' %}
+{% set data_type, form_enc = 'cdf_forecast_group', 'application/json' %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}

--- a/sfa_dash/templates/forms/cdf_forecast_group_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_group_form.html
@@ -1,14 +1,19 @@
-{% extends "dash/data.html" %}
-{% import "forms/form_macros.jinja" as form %}
+{# {% extends "dash/data.html" %}
 {% set page_title = 'Create New Probabilistic Forecast' %}
 {% block content %}
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
+<form action="{{ url_for('forms.create_cdf_forecast', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
+  <div class="form-group">
+
+#}
+{% extends "forms/base_form.html" %}
+{% import "forms/form_macros.jinja" as form %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
-<form action="{{ url_for('forms.create_cdf_forecast_group', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="cdf-forecast-form">
-  <div class="form-group">
+
+{% block fields %}
     <input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
 	<div class="form-element">
       {{ form.input('Name', 'text', 'name', 'Name for the Forecast',
@@ -75,7 +80,9 @@
 	  <label>Extra Parameters</label>
       <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
 	</div>
-  </div>
-</form>
+
+ {% endblock %}
+ {# </div>
+ </form>
 <button type="submit" form="cdf-forecast-form" value="Submit" class="btn btn-primary">Submit</button>
-{% endblock %}
+{% endblock %} #}

--- a/sfa_dash/templates/forms/cdf_forecast_upload_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_upload_form.html
@@ -1,6 +1,5 @@
 {% extends "forms/base/upload_form.html" %}
 {% set page_title = 'Upload Forecast data' %}
-{% set form_title = "Upload data for Forecast 'AC Power'" %}
 {% set data_type = "cdf_forecast" %}
 {% block fields %}
 	<div class="form-element">

--- a/sfa_dash/templates/forms/cdf_forecast_upload_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_upload_form.html
@@ -1,11 +1,8 @@
-{% extends "dash/data.html" %}
+{% extends "forms/base/upload_form.html" %}
 {% set page_title = 'Upload Forecast data' %}
-{% block content %}
-{% include "sections/notifications.html" %}
-{{ metadata | safe }}
-<h3>Upload data for Forecast 'AC Power'</h3>
-<form action="{{ url_for('forms.upload_cdf_forecast_data', uuid=uuid) }}" method="post" id="cdf-forecast-upload-form" enctype="multipart/form-data">
-  <div class="form-group">
+{% set form_title = "Upload data for Forecast 'AC Power'" %}
+{% set data_type = "cdf_forecast" %}
+{% block fields %}
 	<div class="form-element">
 	  <label>My data is formatted in:</label><br>
 	  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="csv" checked/>CSV
@@ -35,14 +32,6 @@ timestamp,value
          }            
     ] 
 }</pre>
-      </div>
-    </div>
-    <div class="form-element full-width">
-      <input type="file" name="cdf_forecast-data" accept=".csv, .json">
-    </div>
   </div>
-</form>
-<div class="form-element">
-  <button type="submit" form="cdf-forecast-upload-form" value="Submit" class="btn btn-primary">Submit</button>
 </div>
 {% endblock %}

--- a/sfa_dash/templates/forms/deletion_form.html
+++ b/sfa_dash/templates/forms/deletion_form.html
@@ -8,5 +8,6 @@
   <p>Are you sure you want to delete this resource? This action is irreversible.</p>
   <button type="submit" form="delete-form" value="Submit" class="btn btn-danger btn-sml">Yes</button>
   <a href="{{ url_for('data_dashboard.' + data_type + '_view', uuid=uuid) }}" class="btn btn-primary">No</a>
+  {{ form.token() }}
 </form>
 {% endblock %}

--- a/sfa_dash/templates/forms/forecast_download_form.html
+++ b/sfa_dash/templates/forms/forecast_download_form.html
@@ -1,43 +1,39 @@
-{% extends "dash/data.html" %}
-{# {% set sidebar = True %} #}
+{% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Forecast data' %}
-{% block content %}
-{{ metadata | safe }}
-<h3>Download data for Forecast 'DA Power'</h3>
-{#<p><b>Available Date Range:</b> <i>2016-01-01T12:00Z</i> to <i>2019-01-01T12:00Z</i></p>#}
-<form action="{{ url_for('forms.download_forecast_data', uuid=uuid) }}" method="post" id="forecast-download">
-  <div class="form-group">
-	<div class="form-element">
-	  <label for="start">Start time:</label>
-	  <input type="datetime-local" id="start" name="period-start">
-    </div>
-    <div class="form-element">
-	  <label for="end">End time:</label>
-	  <input type="datetime-local" id="end" name="period-end">
-    </div>
-	<div class="form-element full-width">
-	  <label for="format">Format</label><br/>
-	  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
-	  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
-	</div>
-	<div class="form-element full-width">
-	  <div class="download-example csv show">
-	  <p>CSV downloads will have the following format.</p>
-	  <pre class="example-text">
+{% set form_title = "Download data for Forecast 'DA Power'" %}
+{% set data_type = 'forecast' %}
+{% block fields %}
+<div class="form-element">
+  <label for="start">Start time:</label>
+  <input type="datetime-local" id="start" name="period-start">
+</div>
+<div class="form-element">
+  <label for="end">End time:</label>
+  <input type="datetime-local" id="end" name="period-end">
+</div>
+<div class="form-element full-width">
+  <label for="format">Format</label><br/>
+  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
+  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
+</div>
+<div class="form-element full-width">
+  <div class="download-example csv show">
+  <p>CSV downloads will have the following format.</p>
+  <pre class="example-text">
 # forecast_id: f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1
 # metadata: https://api.solarforecastarbiter.org/forecasts/f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1/metadata
 timestamp,value
 2018-11-22T18:01:00Z,10.23
 2018-11-22T18:02:00Z,10.67
 2018-11-22T18:03:00Z,10.67
-	  </pre>
+  </pre>
 
-	  </div>
-	</div>
-    <div class="form-element full-width">
-	  <div class="download-example json collapse">
-	    <p>JSON downloads will have the following format.</p>
-		<pre class="example-text">{
+  </div>
+</div>
+<div class="form-element full-width">
+  <div class="download-example json collapse">
+    <p>JSON downloads will have the following format.</p>
+	<pre class="example-text">{
     “forecast_id”: “f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1',
     "_links": {
         "metadata": "https://api.solarforecastarbiter.org/forecasts/f79e4f84-e2c3-11e8-9f32-f2801f1b9fd1/metadata",
@@ -57,12 +53,6 @@ timestamp,value
          }
     ] 
 }</pre>
-	  </div>
-	</div>
-
   </div>
-</form>
-<div class="form-element">
-  <button type="submit" form="forecast-download" value="Submit" class="btn btn-primary">Download</button>
 </div>
 {% endblock %}

--- a/sfa_dash/templates/forms/forecast_download_form.html
+++ b/sfa_dash/templates/forms/forecast_download_form.html
@@ -1,6 +1,5 @@
 {% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Forecast data' %}
-{% set form_title = "Download data for Forecast 'DA Power'" %}
 {% set data_type = 'forecast' %}
 {% block fields %}
 <div class="form-element">

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -1,62 +1,56 @@
-{% extends "dash/data.html" %}
+{% extends "forms/base_form.html" %}
 {% import "forms/form_macros.jinja" as form %}
 {% set page_title = 'Create New Forecast' %}
-{% block content %}
-{{ metadata | safe }}
-{% include "sections/notifications.html" %}
+{% set data_type = 'forecast' %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
-<form action="{{ url_for('forms.create_site_forecast', site_id=site_metadata['site_id']) }}" method="post" enctype='application/json' id="forecast-form">
-  <div class="form-group">
-    <input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
-	<div class="form-element">
-      {{ form.input('Name', 'text', 'name', 'Name for the Forecast',
-                    required=True, form_data=form_data) }}
-	</div>
-	<div class="form-element">
-      {{ form.select('Variable', 'variable',
-                      variable_options,
-                      form_data=form_data) }}
-	</div>
-    <div class="form-element">
-      {{ form.time_of_day('Issue time of day', 'issue_time',
-                          'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }}
-    </div>
-    <div class="form-element">
-        {{ form.timedelta('Lead time to start', 'lead_time',
-                          'The difference between the issue time and the start of the first forecast interval. Values must be integers.')}}
-	</div>
-	<div class="form-element">
-      {{ form.timedelta('Run length/Issue frequency', 'run_length',
-                        'The total length of a single issued forecast run. To enforce a continuous, non-overlapping sequence, this is equal to the forecast run issue frequency. Values must be integers.') }}
-	</div>
-	<div class="form-element">
-      {{ form.timedelta('Interval length', 'interval_length',
-                        'The length of time that each data point represents. Values must be integers.') }}
-	</div>
-    <div class="form-element">
-      {{ form.select('Interval Label', 'interval_label',
-                     {'beginning': 'Beginning',
-                      'ending': 'Ending',
-                      'instant': 'Instant'},
-                      'Indicates if a time labels the start or the end of an interval.') }}
-    </div>
-    <div class="form-element">
-      {{ form.select('Interval Value Type', 'interval_value_type',
-                      {"interval_mean": "Mean",
-					   "interval_min": "Min",
-                       "interval_max": "Max",
-                       "interval_median": "Median",
-                       "percentile": "Percentile",
-                       "instantaneous": "Instantaneous"},
-                       form_data=form_data) }}
-    </div>
-	<div class="form-element full-width">
-	  <label>Extra Parameters</label>
-      <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
-	</div>
-  </div>
-</form>
-<button type="submit" form="forecast-form" value="Submit" class="btn btn-primary">Submit</button>
+{% block fields %}
+<input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
+<div class="form-element">
+  {{ form.input('Name', 'text', 'name', 'Name for the Forecast',
+                required=True, form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.select('Variable', 'variable',
+                 variable_options,
+                 form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.time_of_day('Issue time of day', 'issue_time',
+                      'The time of day that a forecast run is issued specified in UTC and in HH:MM format, e.g. 00:30. For forecast runs issued multiple times within one day (e.g. hourly), this specifies the first issue time of day. Additional issue times are uniquely determined by the first issue time and the run length & issue frequency attribute.') }}
+</div>
+<div class="form-element">
+    {{ form.timedelta('Lead time to start', 'lead_time',
+                      'The difference between the issue time and the start of the first forecast interval. Values must be integers.')}}
+</div>
+<div class="form-element">
+  {{ form.timedelta('Run length/Issue frequency', 'run_length',
+                    'The total length of a single issued forecast run. To enforce a continuous, non-overlapping sequence, this is equal to the forecast run issue frequency. Values must be integers.') }}
+</div>
+<div class="form-element">
+  {{ form.timedelta('Interval length', 'interval_length',
+                    'The length of time that each data point represents. Values must be integers.') }}
+</div>
+<div class="form-element">
+  {{ form.select('Interval Label', 'interval_label',
+                 {'beginning': 'Beginning',
+                  'ending': 'Ending',
+                  'instant': 'Instant'},
+                  'Indicates if a time labels the start or the end of an interval.') }}
+</div>
+<div class="form-element">
+  {{ form.select('Interval Value Type', 'interval_value_type',
+                  {"interval_mean": "Mean",
+				   "interval_min": "Min",
+                   "interval_max": "Max",
+                   "interval_median": "Median",
+                   "percentile": "Percentile",
+                   "instantaneous": "Instantaneous"},
+                   form_data=form_data) }}
+</div>
+<div class="form-element full-width">
+  <label>Extra Parameters</label>
+  <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
+</div>
 {% endblock %}

--- a/sfa_dash/templates/forms/forecast_form.html
+++ b/sfa_dash/templates/forms/forecast_form.html
@@ -1,7 +1,7 @@
-{% extends "forms/base_form.html" %}
+{% extends "forms/base/creation_form.html" %}
 {% import "forms/form_macros.jinja" as form %}
 {% set page_title = 'Create New Forecast' %}
-{% set data_type = 'forecast' %}
+{% set data_type, form_enc = 'forecast', 'application/json' %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}

--- a/sfa_dash/templates/forms/forecast_upload_form.html
+++ b/sfa_dash/templates/forms/forecast_upload_form.html
@@ -1,6 +1,5 @@
 {% extends "forms/base/upload_form.html" %}
 {% set page_title = 'Upload Forecast data' %}
-{% set form_title = "Upload data for Forecast 'AC Power'" %}
 {% set data_type = 'forecast' %}
 {% block fields %}
 <div class="form-element">

--- a/sfa_dash/templates/forms/forecast_upload_form.html
+++ b/sfa_dash/templates/forms/forecast_upload_form.html
@@ -1,28 +1,25 @@
-{% extends "dash/data.html" %}
+{% extends "forms/base/upload_form.html" %}
 {% set page_title = 'Upload Forecast data' %}
-{% block content %}
-{% include "sections/notifications.html" %}
-{{ metadata | safe }}
-<h3>Upload data for Forecast 'AC Power'</h3>
-<form action="{{ url_for('forms.upload_forecast_data', uuid=uuid) }}" method="post" id="forecast-upload-form" enctype="multipart/form-data">
-  <div class="form-group">
-	<div class="form-element">
-	  <label>My data is formatted in:</label><br>
-	  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="csv" checked/>CSV
-      <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="json"/>JSON
-	</div>
-	<div class="form-element full-width">
-      <div class="upload-example csv show">
-		<p>Forecast data in CSV format should follow the formatting of the example below.</p>
-	    <pre class="example-text">
+{% set form_title = "Upload data for Forecast 'AC Power'" %}
+{% set data_type = 'forecast' %}
+{% block fields %}
+<div class="form-element">
+  <label>My data is formatted in:</label><br>
+  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="csv" checked/>CSV
+  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="json"/>JSON
+</div>
+<div class="form-element full-width">
+  <div class="upload-example csv show">
+	<p>Forecast data in CSV format should follow the formatting of the example below.</p>
+    <pre class="example-text">
 # optional header, ignored by Solar Forecast Arbiter 
 timestamp,value
 2018-11-22T12:00:00Z,10.23
 2018-11-22T12:05:00Z,10.67</pre>
-	  </div>
-	  <div class="upload-example json collapse">
-        <p>Forecast data in JSON format should follow the formatting of the example below.</p>
-        <pre class="example-text">{ 
+  </div>
+  <div class="upload-example json collapse">
+    <p>Forecast data in JSON format should follow the formatting of the example below.</p>
+    <pre class="example-text">{ 
     “id”: “testid”, # optional, for uploader’s record 
     “values”: [
         { 
@@ -35,14 +32,6 @@ timestamp,value
          }            
     ] 
 }</pre>
-      </div>
-    </div>
-    <div class="form-element full-width">
-      <input type="file" name="forecast-data" accept=".csv, .json">
-    </div>
   </div>
-</form>
-<div class="form-element">
-  <button type="submit" form="forecast-upload-form" value="Submit" class="btn btn-primary">Submit</button>
 </div>
 {% endblock %}

--- a/sfa_dash/templates/forms/form_macros.jinja
+++ b/sfa_dash/templates/forms/form_macros.jinja
@@ -87,3 +87,7 @@ UTC
 <span class="help-text text-muted  time-field-help {{ name }}-help-text collapse">{{ help_text }}</span>
 {% endif %}
 {% endmacro %}
+
+{% macro token() %}
+<input type="hidden" name="_csrf_token" value="{{ csrf_token() }}">
+{% endmacro %}

--- a/sfa_dash/templates/forms/observation_download_form.html
+++ b/sfa_dash/templates/forms/observation_download_form.html
@@ -1,6 +1,5 @@
 {% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Observation data' %}
-{% set form_title = "Download data for Observation 'GHI Instrument 1'" %}
 {% set data_type = 'observation' %}
 {% block fields %}
 <div class="form-element">

--- a/sfa_dash/templates/forms/observation_download_form.html
+++ b/sfa_dash/templates/forms/observation_download_form.html
@@ -1,41 +1,37 @@
-{% extends "dash/data.html" %}
-{# {% set sidebar = True %} #}
+{% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Observation data' %}
-{% block content %}
-{{ metadata | safe }}
-<h3>Download data for Observation 'GHI Instrument 1'</h3>
-{# <p><b>Available Date Range:</b> 2016-01-01T12:00Z to 2019-01-01T12:00Z</p> #}
-<form action="{{ url_for('forms.download_observation_data', uuid=uuid) }}" method="post" id="observation-download">
-  <div class="form-group">
-	<div class="form-element">
-	  <label for="start">Start time:</label>
-	  <input type="datetime-local" id="start" name="period-start">
-    </div>
-    <div class="form-element">
-	  <label for="end">End time:</label>
-	  <input type="datetime-local" id="end" name="period-end">
-    </div>
-    <div class="form-element full-width">
-      <label for="format">Format</label><br/>
-      <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
-      <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
-    </div>
-    <div class="form-element full-width">
-      <div class="download-example csv show">
-      <p>CSV downloads will have the following format.</p>
-      <pre class="example-text">
+{% set form_title = "Download data for Observation 'GHI Instrument 1'" %}
+{% set data_type = 'observation' %}
+{% block fields %}
+<div class="form-element">
+  <label for="start">Start time:</label>
+  <input type="datetime-local" id="start" name="period-start">
+</div>
+<div class="form-element">
+  <label for="end">End time:</label>
+  <input type="datetime-local" id="end" name="period-end">
+</div>
+<div class="form-element full-width">
+  <label for="format">Format</label><br/>
+  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
+  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
+</div>
+<div class="form-element full-width">
+  <div class="download-example csv show">
+  <p>CSV downloads will have the following format.</p>
+  <pre class="example-text">
 # observation_id: 123e4567-e89b-12d3-a456-426655440000
 # metadata: https://api.solarforecastarbiter.org/observations/123e4567-e89b-12d3-a456-426655440000/metadata
 timestamp,value,quality_flag
 2018-11-22T18:01:00Z,10.23,0
 2018-11-22T18:02:00Z,10.67,0
 2018-11-22T18:03:00Z,10.67,0
-      </pre>
-    </div>
-    <div class="form-element full-width">
-      <div class="download-example json collapse">
-        <p>JSON downloads will have the following format.</p>
-        <pre class="example-text">{
+  </pre>
+</div>
+<div class="form-element full-width">
+  <div class="download-example json collapse">
+    <p>JSON downloads will have the following format.</p>
+    <pre class="example-text">{
     "id": "123e4567-e89b-12d3-a456-426655440000",
     "_links": {
         "metadata": "https://api.solarforecastarbiter.org/observations/123e4567-e89b-12d3-a456-426655440000/metadata",
@@ -58,10 +54,6 @@ timestamp,value,quality_flag
          }
     ]
 }</pre>
-      </div>
-    </div>
-</form>
-<div class="form-element">
-  <button type="submit" form="observation-download" value="Submit" class="btn btn-primary">Download</button>
+  </div>
 </div>
 {% endblock %}

--- a/sfa_dash/templates/forms/observation_form.html
+++ b/sfa_dash/templates/forms/observation_form.html
@@ -1,7 +1,7 @@
-{% extends "forms/base_form.html" %}
+{% extends "forms/base/creation_form.html" %}
 {% import "forms/form_macros.jinja" as form %}
 {% set page_title = 'Create New Observation' %}
-{% set data_type = 'observation' %}
+{% set data_type, form_enc  = 'observation', 'application/json' %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}

--- a/sfa_dash/templates/forms/observation_form.html
+++ b/sfa_dash/templates/forms/observation_form.html
@@ -1,50 +1,44 @@
-{% extends "dash/data.html" %}
+{% extends "forms/base_form.html" %}
 {% import "forms/form_macros.jinja" as form %}
 {% set page_title = 'Create New Observation' %}
-{% block content %}
-{{ metadata | safe }}
-{% include "sections/notifications.html" %}
+{% set data_type = 'observation' %}
 {% if form_data is not defined %}
 {% set form_data = {} %}
 {% endif %}
-<form action="{{ url_for('forms.create_site_observation', site_id=site_metadata['site_id']) }}" method="post" id="observation-form", enctype='application/json'>
-  <div class="form-group">
-    <input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
-	<div class="form-element">
-      {{ form.input('Name', 'text', 'name', 'Name of the Observation.', form_data=form_data) }}
-	</div>
-	<div class="form-element">
-      {{ form.select('Variable', 'variable',
-                     variable_options,
-                     form_data=form_data) }}
-	</div>
-	<div class="form-element">
-      {{ form.select('Interval Value Type', 'interval_value_type',
-                      {"interval_mean": "Interval Mean",
-                       "instantaneous": "Instantaneous"},
-                       form_data=form_data) }}
-	</div>
-    <div class="form-element">
-      {{ form.input('Uncertainty', 'number', 'uncertainty',
-                    'A measure of uncertainty of Observation values.',
-                    form_data=form_data) }}
-	</div>
-    <div class="form-element">
-      {{ form.timedelta('Interval length', 'interval_length',
-                        'The length of time that each data point represents. Values must be integers.') }}
-    </div>
-    <div class="form-element">
-      {{ form.select('Interval Label', 'interval_label',
-					 {'beginning': 'Beginning',
-					  'ending': 'Ending',
-					  'instant': 'Instant'},
-					  'Indicates if a time labels the start or the end of an interval.') }}
-    </div>
-    <div class="form-element full-width">
-	  <label>Extra Parameters (Optional)</label>
-      <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON"></textarea>
-	</div>
-  </div>
-</form>
-<button type="submit" form="observation-form" value="Submit" class="btn btn-primary">Submit</button>
+{% block fields %}
+<input type="hidden" name="site_id" value="{{ site_metadata['site_id'] }}">
+<div class="form-element">
+  {{ form.input('Name', 'text', 'name', 'Name of the Observation.', form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.select('Variable', 'variable',
+                 variable_options,
+                 form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.select('Interval Value Type', 'interval_value_type',
+                  {"interval_mean": "Interval Mean",
+                   "instantaneous": "Instantaneous"},
+                   form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.input('Uncertainty', 'number', 'uncertainty',
+                'A measure of uncertainty of Observation values.',
+                form_data=form_data) }}
+</div>
+<div class="form-element">
+  {{ form.timedelta('Interval length', 'interval_length',
+                    'The length of time that each data point represents. Values must be integers.') }}
+</div>
+<div class="form-element">
+  {{ form.select('Interval Label', 'interval_label',
+				 {'beginning': 'Beginning',
+				  'ending': 'Ending',
+				  'instant': 'Instant'},
+				  'Indicates if a time labels the start or the end of an interval.') }}
+</div>
+<div class="form-element full-width">
+  <label>Extra Parameters (Optional)</label>
+  <textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON"></textarea>
+</div>
 {% endblock %}

--- a/sfa_dash/templates/forms/observation_upload_form.html
+++ b/sfa_dash/templates/forms/observation_upload_form.html
@@ -1,28 +1,25 @@
-{% extends "dash/data.html" %}
+{% extends "forms/base/upload_form.html" %}
 {% set page_title = 'Upload Observation data' %}
-{% block content %}
-{% include "sections/notifications.html" %}
-{{ metadata | safe }}
-<h3>Upload data for Observation 'GHI Instrument 1'</h3>
-<form action="{{url_for('forms.upload_observation_data', uuid=uuid) }}" method="post" id="obs-upload-form" enctype="multipart/form-data">
-  <div class="form-group">
-	<div class="form-element">
-	  <label>My data is formatted in:</label><br>
-	  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="csv" checked/>CSV
-      <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="json"/>JSON
-	</div>
-	<div class="form-element full-width">
-      <div class="upload-example csv show">
-		<p>Observation data in CSV format should follow the formatting of the example below.</p>
-	    <pre class="example-text">
+{% set form_title = "Upload data for Observation 'GHI Instrument 1'" %}
+{% set data_type = 'observation' %}
+{% block fields %}
+<div class="form-element">
+  <label>My data is formatted in:</label><br>
+  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="csv" checked/>CSV
+  <input type="radio" data-toggle="collapse" data-target=".upload-example" name="file-format" value="json"/>JSON
+</div>
+<div class="form-element full-width">
+  <div class="upload-example csv show">
+	<p>Observation data in CSV format should follow the formatting of the example below.</p>
+    <pre class="example-text">
 # optional header, ignored by Solar Forecast Arbiter 
 timestamp,value,quality_flag
 2018-11-22T12:00:00Z,10.23,0
 2018-11-22T12:05:00Z,10.67,0</pre>
-	  </div>
-	  <div class="upload-example json collapse">
-		<p>Observation data in JSON format should follow the formatting of the example below.</p>
-	    <pre class="example-text">{ 
+  </div>
+  <div class="upload-example json collapse">
+	<p>Observation data in JSON format should follow the formatting of the example below.</p>
+    <pre class="example-text">{ 
     “id”: “testid”, # optional, for uploader’s record 
     “values”: [ 
         { 
@@ -37,14 +34,6 @@ timestamp,value,quality_flag
          }            
     ] 
 }</pre>
-	  </div>
-	</div>	
-  	<div class="form-element full-width">
-	  <input type="file" name="observation-data" accept=".csv, .json">
-	</div>
   </div>
-</form>
-<div class="form-element">
-  <button type="submit" form="obs-upload-form" value="Submit" class="btn btn-primary">Submit</button>
-</div>
+</div>	
 {% endblock %}

--- a/sfa_dash/templates/forms/observation_upload_form.html
+++ b/sfa_dash/templates/forms/observation_upload_form.html
@@ -1,6 +1,5 @@
 {% extends "forms/base/upload_form.html" %}
 {% set page_title = 'Upload Observation data' %}
-{% set form_title = "Upload data for Observation 'GHI Instrument 1'" %}
 {% set data_type = 'observation' %}
 {% block fields %}
 <div class="form-element">


### PR DESCRIPTION
Initializes Flask SeaSurf and adds a csrf token to all forms. Most of the changes here are form refactoring. I've extracted most of the repeated html into files in `/templates/form/base`. These templates include the <form> elements, and common input elements such as the hidden csrf token fields.
The files changed in `template/forms` are largely the same, with the code that is now found in the base forms removed.
I've also renamed some of the views with a predictable pattern so that they may be selected programatically by i.e. something like download_{data_type}_data, where data type is 'observation', 'forecast' or 'cdf_forecast'.
closes #34 