### PR TITLE
timedelta filter, and reorganize metadata templates

### DIFF
--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -18,6 +18,45 @@ def api_varname_to_units(api_varname):
     return variable_mapping[api_varname][1]
 
 
+def display_timedelta(minutes):
+    """Converts timedelta in seconds to human friendly format.
+
+    Parameters
+    ----------
+    minutes: int
+
+    Returns
+    -------
+    string
+        The timedelta in 'x days y hours z minutes' format.
+
+    Raises
+    ------
+    ValueError
+        If the timedelta is negative or evaluates to 0.
+    """
+    def plural(num):
+        if num > 1:
+            return 's'
+        else:
+            return ''
+    if minutes <= 0:
+        raise ValueError
+    days = minutes // 1440
+    hours = minutes // 60 % 24
+    minutes = minutes % 60
+    time_elements = []
+    if days > 0:
+        time_elements.append(f'{days} day{plural(days)}')
+    if hours > 0:
+        time_elements.append(f'{hours} hour{plural(hours)}')
+    if minutes > 0:
+        time_elements.append(f'{minutes} minute{plural(minutes)}')
+    time_string = ' '.join(time_elements)
+    return time_string
+
+
 def register_jinja_filters(app):
     app.jinja_env.filters['convert_varname'] = api_to_dash_varname
     app.jinja_env.filters['var_to_units'] = api_varname_to_units
+    app.jinja_env.filters['display_timedelta'] = display_timedelta

--- a/sfa_dash/templates/data/metadata/cdf_forecast_group_metadata.html
+++ b/sfa_dash/templates/data/metadata/cdf_forecast_group_metadata.html
@@ -1,19 +1,6 @@
-{% extends "data/metadata/meta_container.html" %}
+{% extends "data/metadata/forecast_metadata.html" %}
 {% import "data/metadata/meta_macro.jinja" as macro %}
 {% set data_type = 'Probabilistic Forecast' %}
-{% block metadata %}
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Name', name) }}
-  {{ macro.li('Site', site_link )}}
-</ul>
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Variable', variable | convert_varname, variable | var_to_units ) }}
-  {{ macro.li('Value type', interval_value_type) }}
-  {{ macro.li('Issue time of day', issue_time_of_day) }}
-  {{ macro.li('Interval label', interval_label) }}
-  {{ macro.li('Interval length', interval_length | string, 'minutes') }}
-  {{ macro.li('Run length / Issue frequency', run_length | string, 'minutes' ) }}
-  {{ macro.li('Lead time to start', lead_time_to_start | string, 'minutes') }}
+{% block cdf_fields %}
   {{ macro.li('Axis', axis) }}
-</ul>
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/cdf_forecast_metadata.html
+++ b/sfa_dash/templates/data/metadata/cdf_forecast_metadata.html
@@ -1,21 +1,7 @@
-{% extends "data/metadata/meta_container.html" %}
-{% import "data/metadata/meta_macro.jinja" as macro %}
+{% extends "data/metadata/forecast_metadata.html" %}
 {% set data_type = 'Probabilistic Forecast Value' %}
-{% block metadata %}
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Name', name) }}
-  {{ macro.li('Site', site_link )}}
-</ul>
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Variable', variable | convert_varname, variable | var_to_units ) }}
-  {{ macro.li('Value type', interval_value_type) }}
-  {{ macro.li('Issue time of day', issue_time_of_day) }}
-  {{ macro.li('Interval label', interval_label) }}
-  {{ macro.li('Interval length', interval_length | string, 'minutes') }}
-  {{ macro.li('Run length / Issue frequency', run_length | string, 'minutes' ) }}
-  {{ macro.li('Lead time to start', lead_time_to_start | string, 'minutes') }}
-  {{ macro.li('Axis', axis) }}
-  {# constant_value will need units dependent on axis, and variable #}
-  {{ macro.li('Constant Value', constant_value |string ) }}
-</ul>
+{% block cdf_fields %}
+{{ macro.li('Axis', axis) }}
+{# constant_value will need units dependent on axis, and variable #}
+{{ macro.li('Constant Value', constant_value |string ) }}
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -1,0 +1,19 @@
+{# Base metadata template for data containers, forecasts, observationsa,
+ cdf_forecasts.
+#}
+{% extends "data/metadata/meta_container.html" %}
+{% import "data/metadata/meta_macro.jinja" as macro %}
+{% block metadata %}
+<ul class="data-metadata-fields col-md-6 col-xs-12">
+      {{ macro.li('Name', name) }}
+      {{ macro.li('Site', site_link )}}
+</ul>
+<ul class="data-metadata-fields col-md-6 col-xs-12">
+  {{ macro.li('Variable', variable |convert_varname, variable | var_to_units) }}
+  {{ macro.li('Value type', interval_value_type) }}
+  {{ macro.li('Interval label', interval_label) }}
+  {{ macro.li('Interval length', interval_length | display_timedelta) }}
+  {% block extra_fields %}
+  {% endblock %}
+</ul>
+{% endblock %}

--- a/sfa_dash/templates/data/metadata/forecast_metadata.html
+++ b/sfa_dash/templates/data/metadata/forecast_metadata.html
@@ -1,19 +1,17 @@
-{% extends "data/metadata/meta_container.html" %}
-{% import "data/metadata/meta_macro.jinja" as macro %}
+{% extends "data/metadata/data_metadata.html" %}
+{# Since we might extend this template, check before overwriting data_tpye #}
+{% if data_type is not defined %} 
 {% set data_type = 'Forecast' %}
-{% block metadata %}
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Name', name) }}
-  {# {{ macro.li('UUID', observation_id) }} #}
-  {{ macro.li('Site', site_link )}}
-</ul>
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Variable', variable |convert_varname, variable | var_to_units) }}
-  {{ macro.li('Value type', interval_value_type) }}
-  {{ macro.li('Issue time of day', issue_time_of_day) }}
-  {{ macro.li('Interval label', interval_label) }}
-  {{ macro.li('Interval length', interval_length | string, 'minutes') }}
-  {{ macro.li('Run length / Issue frequency', run_length | string, 'minutes' ) }}
-  {{ macro.li('Lead time to start', lead_time_to_start | string, 'minutes') }}
-</ul>
+{% endif %}
+{% block extra_fields %}
+{{ macro.li('Issue time of day', issue_time_of_day) }}
+{{ macro.li('Run length / Issue frequency', run_length | display_timedelta) }}
+{{ macro.li('Lead time to start', lead_time_to_start | display_timedelta) }}
+{# 
+We don't expect cdf_fields to be defined on a regular forecast,
+but we'll extend this template with extra probabilistic forecast
+fields.
+#}
+{% block cdf_fields %}
+{% endblock %}
 {% endblock %}

--- a/sfa_dash/templates/data/metadata/meta_container.html
+++ b/sfa_dash/templates/data/metadata/meta_container.html
@@ -2,9 +2,6 @@
   <h3 class="section-title">{{ data_type }} Metadata</h3>
   <div class="row">
 	{% block metadata %}
-    <ul class="data-metadata-fields col-md-6 col-xs-12">
-	  {{ macro.li('Name', name) }}
-    </ul>
     {% endblock %}
   </div>
 </div>

--- a/sfa_dash/templates/data/metadata/meta_macro.jinja
+++ b/sfa_dash/templates/data/metadata/meta_macro.jinja
@@ -1,5 +1,5 @@
 {% macro li(label, attribute, unit='') %}
 {% if (attribute is not none) and (attribute != 'null') %}
-<li class="metadata-field"><span class="data-metadata-label">{{ label }}: </span>{{ attribute | string | replace("_", " ")  + ' ' + unit }}</li>
+<li class="metadata-field"><span class="data-metadata-label">{{ label }}: </span>{{ attribute | string | replace("_", " ")}} {% if unit != '' %} {{ unit }} {% endif %}</li>
 {% endif %}
 {% endmacro %}

--- a/sfa_dash/templates/data/metadata/observation_metadata.html
+++ b/sfa_dash/templates/data/metadata/observation_metadata.html
@@ -1,15 +1,2 @@
-{% extends "data/metadata/meta_container.html" %}
-{% import "data/metadata/meta_macro.jinja" as macro %}
+{% extends "data/metadata/data_metadata.html" %}
 {% set data_type = 'Observation' %}
-{% block metadata %}
-<ul class="data-metadata-fields col-md-6 col-xs-12">
-  {{ macro.li('Name', name) }}
-  {{ macro.li('Site', site_link) }}
-</ul>
-<ul class="data-metadata-fields col-md-6 col-xs-12">
- {{ macro.li('Variable', variable | convert_varname, variable | var_to_units) }}
- {{ macro.li('Value Type', interval_value_type) }}
- {{ macro.li('Interval Label', interval_label) }}
- {{ macro.li('Interval Length', interval_length | string, 'minutes') }}
-</ul>
-{% endblock %}

--- a/sfa_dash/tests/test_filters.py
+++ b/sfa_dash/tests/test_filters.py
@@ -1,0 +1,25 @@
+import pytest
+
+
+from sfa_dash import filters
+
+
+@pytest.mark.parametrize('minutes,expected', [
+    (1500, '1 day 1 hour'),
+    (1501, '1 day 1 hour 1 minute'),
+    (3002, '2 days 2 hours 2 minutes'),
+    (4320, '3 days'),
+    (1440, '1 day'),
+    (300, '5 hours'),
+    (60, '1 hour'),
+    (30, '30 minutes'),
+    (1, '1 minute'),
+])
+def test_display_timedelta(minutes, expected):
+    assert filters.display_timedelta(minutes) == expected
+
+
+@pytest.mark.paramtrize('minutes', [-1, 0])
+def test_display_timedelta_failure():
+    with pytest.raises(ValueError):
+        filters.display_timedelta(0)


### PR DESCRIPTION
closes #37 

Adds a filter for converting timedeltas in seconds to a more human friendly format.  Refactors templates for observations, forecasts and cdf_forecasts so they don't repeat common metadata fields.