### PR TITLE
Add a create button to obs, fx, cdf fx listings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(
         'cryptography',
         'blinker',
         'bokeh'
-        ]
+    ]
 )

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -38,11 +38,11 @@ class SiteDashView(BaseView):
         temp_args = {}
         subnav_kwargs = {
             'forecasts_url': url_for('data_dashboard.forecasts',
-                                     site_id=self.metadata['site_id']),
+                                     uuid=self.metadata['site_id']),
             'observations_url': url_for('data_dashboard.observations',
-                                        site_id=self.metadata['site_id']),
+                                        uuid=self.metadata['site_id']),
             'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
-                                         site_id=self.metadata['site_id'])
+                                         uuid=self.metadata['site_id'])
         }
         temp_args['subnav'] = self.format_subnav(**subnav_kwargs)
         temp_args['breadcrumb'] = self.breadcrumb_html()

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -1,3 +1,6 @@
+"""Flask endpoints for listing Observations, Forecasts and CDF Forecasts.
+Defers actual table creation and rendering to DataTables in the util module.
+"""
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.blueprints.util import DataTables
 from sfa_dash.api_interface import sites
@@ -54,13 +57,14 @@ class DataListingView(BaseView):
         """Create a dictionary containing the required arguments for the template
         """
         template_args = {}
+        uuid = request.args.get('uuid')
         subnav_kwargs = {
             'observations_url': url_for('data_dashboard.observations',
-                                        **kwargs),
+                                        uuid=uuid),
             'forecasts_url': url_for('data_dashboard.forecasts',
-                                     **kwargs),
+                                     uuid=uuid),
             'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
-                                         **kwargs)
+                                         uuid=uuid)
         }
         template_args['subnav'] = self.format_subnav(**subnav_kwargs)
         template_args['data_table'] = self.table_function(**kwargs)
@@ -71,8 +75,12 @@ class DataListingView(BaseView):
     def get(self, **kwargs):
         """
         """
-        site_id = request.args.get('site_id')
-        if site_id is not None:
-            kwargs.update({'site_id': site_id})
+        # Check for a uuid parameter indicating we should filter by site.
+        # otherwise, set the create key to pass to the site listing page
+        uuid = request.args.get('uuid')
+        if uuid is not None:
+            kwargs.update({'site_id': uuid})
+        else:
+            kwargs.update({'create': self.data_type})
         return render_template(self.template,
                                **self.get_template_args(**kwargs))

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -76,11 +76,10 @@ class DataListingView(BaseView):
         """
         """
         # Check for a uuid parameter indicating we should filter by site.
-        # otherwise, set the create key to pass to the site listing page
+        # otherwise, set the create key to pass as a query parameter to
+        # the site listing page.
         uuid = request.args.get('uuid')
         if uuid is not None:
             kwargs.update({'site_id': uuid})
-        else:
-            kwargs.update({'create': self.data_type})
         return render_template(self.template,
                                **self.get_template_args(**kwargs))

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -218,29 +218,29 @@ class CreateForm(MetadataForm):
     def render_metadata_section(self, metadata):
         return render_template(self.metadata_template, **metadata)
 
-    def get(self, site_id=None):
+    def get(self, uuid=None):
         template_args = {}
-        if site_id is not None:
-            site_metadata = self.get_site_metadata(site_id)
+        if uuid is not None:
+            site_metadata = self.get_site_metadata(uuid)
             template_args['site_metadata'] = site_metadata
             template_args['metadata'] = self.render_metadata_section(
                 site_metadata)
         return render_template(self.template, **template_args)
 
-    def post(self, site_id=None):
+    def post(self, uuid=None):
         form_data = request.form
         formatted_form = self.formatter(form_data)
         response = self.api_handle.post_metadata(formatted_form)
         template_args = {}
-        if site_id is not None:
-            site_metadata = self.get_site_metadata(site_id)
+        if uuid is not None:
+            site_metadata = self.get_site_metadata(uuid)
             template_args['site_metadata'] = site_metadata
             template_args['metadata'] = self.render_metadata_section(
                 site_metadata)
         if response.status_code == 201:
-            uuid = response.text
+            created_uuid = response.text
             return redirect(url_for(f'data_dashboard.{self.data_type}_view',
-                                    uuid=uuid))
+                                    uuid=created_uuid))
         elif response.status_code == 400:
             errors = response.json()['errors']
             template_args['errors'] = self.flatten_dict(errors)
@@ -394,13 +394,13 @@ forms_blp = Blueprint('forms', 'forms')
 forms_blp.add_url_rule('/sites/create',
                        view_func=CreateForm.as_view('create_site',
                                                     data_type='site'))
-forms_blp.add_url_rule('/sites/<site_id>/observations/create',
+forms_blp.add_url_rule('/sites/<uuid>/observations/create',
                        view_func=CreateForm.as_view('create_observation',
                                                     data_type='observation'))
-forms_blp.add_url_rule('/sites/<site_id>/forecasts/single/create',
+forms_blp.add_url_rule('/sites/<uuid>/forecasts/single/create',
                        view_func=CreateForm.as_view('create_forecast',
                                                     data_type='forecast'))
-forms_blp.add_url_rule('/sites/<site_id>/forecasts/cdf/create',
+forms_blp.add_url_rule('/sites/<uuid>/forecasts/cdf/create',
                        view_func=CreateForm.as_view(
                            'create_cdf_forecast_group',
                            data_type='cdf_forecast_group'))

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -211,7 +211,7 @@ class SingleCDFForecastGroupView(DataDashView):
             text=self.metadata['site']['name'])
         breadcrumb += breadcrumb_format.format(
             url=url_for('data_dashboard.cdf_forecast_groups',
-                        site_id=self.metadata['site_id']),
+                        uuid=self.metadata['site_id']),
             text='CDF Forecasts')
         breadcrumb += breadcrumb_format.format(
             url=url_for('data_dashboard.cdf_forecast_group_view',

--- a/sfa_dash/blueprints/sites.py
+++ b/sfa_dash/blueprints/sites.py
@@ -5,6 +5,8 @@ from flask import render_template, url_for, request, abort
 
 
 class SitesListingView(SiteDashView):
+    """Render a page with a table listing Sites.
+    """
     template = 'org/obs.html'
 
     def breadcrumb_html(self, site=None, **kwargs):
@@ -20,15 +22,22 @@ class SitesListingView(SiteDashView):
         template_args = {}
         template_args['data_table'] = DataTables.get_site_table(**kwargs)
         template_args['current_path'] = request.path
-        template_args['breadcrumb'] = self.breadcrumb_html(**kwargs)
+        if 'create' in kwargs:
+            template_args['page_title'] = f"Select a Site"
+        else:
+            template_args['breadcrumb'] = self.breadcrumb_html(**kwargs)
         return template_args
 
     def get(self, **kwargs):
+        # Update kwargs with the create query parameter
+        kwargs.update({'create': request.args.get('create')})
         return render_template(self.template,
                                **self.get_template_args(**kwargs))
 
 
 class SingleSiteView(SiteDashView):
+    """Render a page to display the metadata of a a single Site.
+    """
     template = 'data/site.html'
 
     def breadcrumb_html(self, **kwargs):

--- a/sfa_dash/templates/dash/site.html
+++ b/sfa_dash/templates/dash/site.html
@@ -1,7 +1,11 @@
 {% extends "base.html" %}
 {% block dash %}
 <!-- org name -->
+{% if page_title is defined %}
+<h2 class="page-title">{{ page_title|safe }}</h2>
+{% else %}
 <h2 class="page-title">{{ breadcrumb|safe }}</h2>
+{% endif %}
 {% include "dash/subnav.html" %}
 {% block content %}{% endblock %}
 {% endblock %}

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -1,11 +1,10 @@
 {% extends "dash/site.html" %}
-{% set page_title = "TEP/Avalon 2" %}
 {% block content %}
 {{ metadata | safe }}
 {% block toolbar %}
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', site_id=site_id) }}">Create new Observation</a>
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', site_id=site_id) }}">Create new Forecast</a>
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', site_id=site_id) }}">Create new Probabilistic Forecast</a>
+  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', uuid=site_id) }}">Create new Observation</a>
+  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', uuid=site_id) }}">Create new Forecast</a>
+  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', uuid=site_id) }}">Create new Probabilistic Forecast</a>
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
 
 {% endblock %}

--- a/sfa_dash/templates/data/table/cdf_forecast_table.html
+++ b/sfa_dash/templates/data/table/cdf_forecast_table.html
@@ -1,8 +1,8 @@
 {% extends "data/table/data_table.html" %}
 {% block tools %}
 <input type="text" placeholder="Search" class="search">
-{% if site_id is defined %}
-<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', site_id=site_id)}}">Create new Probabilistic Forecast</a>
+{% if creation_link is defined %}
+<a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Probabilistic Forecast</a>
 {% endif %}
 {% endblock %}
 {% import "data/table/forecast_macro.jinja" as table_macro %}

--- a/sfa_dash/templates/data/table/forecast_table.html
+++ b/sfa_dash/templates/data/table/forecast_table.html
@@ -1,8 +1,8 @@
 {% extends "data/table/data_table.html" %}
 {% block tools %}
 <input type="text" placeholder="Search" class="search">
-{% if site_id is defined %}
-<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', site_id=site_id)}}">Create new Forecast</a>
+{% if creation_link is defined %}
+<a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Forecast</a>
 {% endif %}
 {% endblock %}
 {% import "data/table/forecast_macro.jinja" as table_macro %}

--- a/sfa_dash/templates/data/table/observation_table.html
+++ b/sfa_dash/templates/data/table/observation_table.html
@@ -1,8 +1,8 @@
 {% extends "data/table/data_table.html" %}
 {% block tools %}
 <input type="text" placeholder="Search" class="search">
-{% if site_id is defined %}
-<a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', site_id=site_id)}}">Create new Observation</a>
+{% if creation_link is defined %}
+<a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Observation</a>
 {% endif %}
 {% endblock %}
 {% import "data/table/observation_macro.jinja" as table_macro %}

--- a/sfa_dash/templates/data/table/site_data_table.html
+++ b/sfa_dash/templates/data/table/site_data_table.html
@@ -1,6 +1,8 @@
 <div class="tools {{ table_type }}-tools mt-1">
   <input type="text" placeholder="Search" class="search">
-  <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_site') }}">Create new Site</a>
+  {% if creation_link is defined %}
+    <a role="button" class="btn btn-primary btn-sm" href="{{ creation_link }}">Create new Site</a>
+  {% endif %}
 </div> 
 <table class="{{ table_type }}-table table results">
   <thead class="{{ table_type }}-thead">

--- a/sfa_dash/templates/forms/base/creation_form.html
+++ b/sfa_dash/templates/forms/base/creation_form.html
@@ -4,7 +4,7 @@
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
 {% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
-<form action="{% if data_type == 'site' %} {{ url_for('forms.create_' + data_type) }}{% else %}{{ url_for('forms.create_' + data_type, site_id=site_metadata['site_id']) }} {% endif %}" method="post" enctype='{{ form_enc }}' id="{{ data_type }}-form">
+<form action="{% if data_type == 'site' %} {{ url_for('forms.create_' + data_type) }}{% else %}{{ url_for('forms.create_' + data_type, uuid=site_metadata['site_id']) }} {% endif %}" method="post" enctype='{{ form_enc }}' id="{{ data_type }}-form">
   <div class="form-group">
     {% block fields %}
     {% endblock %}


### PR DESCRIPTION
Adds a button to the listing pages without site. "Create" buttons drop people on the Sites listing page with the query parameter `create=<type>` where type is 'observation', 'forecast' or 'cdf_forecast_group'
. Each Site's title will link to a creation form of the given type for that Site.