### PR TITLE
Hide modeling parameters for weather stations

### DIFF
--- a/sfa_dash/templates/data/metadata/site_metadata.html
+++ b/sfa_dash/templates/data/metadata/site_metadata.html
@@ -10,7 +10,7 @@
   {{ macro.li('Elevation', elevation | string, 'm') }}
 </ul>
 <ul class="data-metadata-fields col-md-6 col-xs-12">
-  {% if modeling_parameters %}
+  {% if modeling_parameters and modeling_parameters['ac_capacity'] is not none %}
     <li><b>Modeling Parameters:</b>
       <div class="data-metadata-field-modeling-parameters pl-2">
         <ul class="data-metadata-fields">


### PR DESCRIPTION
closes #58 
Checks to see if modeling parameters exists and if 'ac_capacity' is None, since it is a required field for all power plants, and weather stations still return the modeling_parameters field with all keys set to None.