### PR TITLE
User admin

### DIFF
--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -83,8 +83,9 @@ def create_app(config=None):
 
     from sfa_dash.blueprints.main import data_dash_blp
     from sfa_dash.blueprints.form import forms_blp
+    from sfa_dash.blueprints.admin import admin_blp
 
-    for blp in (data_dash_blp, forms_blp):
+    for blp in (data_dash_blp, forms_blp, admin_blp):
         blp.before_request(protect_endpoint)
         app.register_blueprint(blp)
     return app

--- a/sfa_dash/api_interface/permissions.py
+++ b/sfa_dash/api_interface/permissions.py
@@ -1,0 +1,11 @@
+from sfa_dash.api_interface import get_request, post_request, delete_request
+
+
+def get_metadata(permission_id):
+    req = get_request(f'/permissions/{permission_id}')
+    return req
+
+
+def list_metadata():
+    req = get_request('/permissions/')
+    return req

--- a/sfa_dash/api_interface/permissions.py
+++ b/sfa_dash/api_interface/permissions.py
@@ -1,4 +1,4 @@
-from sfa_dash.api_interface import get_request, post_request, delete_request
+from sfa_dash.api_interface import get_request
 
 
 def get_metadata(permission_id):

--- a/sfa_dash/api_interface/roles.py
+++ b/sfa_dash/api_interface/roles.py
@@ -1,4 +1,5 @@
-from sfa_dash.api_interface import get_request, post_request, delete_request
+from sfa_dash.api_interface import get_request
+
 
 def get_metadata(role_id):
     req = get_request(f'/roles/{role_id}')

--- a/sfa_dash/api_interface/roles.py
+++ b/sfa_dash/api_interface/roles.py
@@ -1,0 +1,10 @@
+from sfa_dash.api_interface import get_request, post_request, delete_request
+
+def get_metadata(role_id):
+    req = get_request(f'/roles/{role_id}')
+    return req
+
+
+def list_metadata():
+    req = get_request('/roles/')
+    return req

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -1,7 +1,7 @@
 from sfa_dash.api_interface import get_request, post_request, delete_request
 
 
-def get_metadta(user_id):
+def get_metadata(user_id):
     req = get_request(f'/users/{user_id}')
     return req
 

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -1,0 +1,11 @@
+from sfa_dash.api_interface import get_request, post_request, delete_request
+
+
+def get_metadta(user_id):
+    req = get_request(f'/users/{user_id}')
+    return req
+
+
+def list_metadata():
+    req = get_request('/users/')
+    return req

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -1,4 +1,4 @@
-from sfa_dash.api_interface import get_request, post_request, delete_request
+from sfa_dash.api_interface import get_request
 
 
 def get_metadata(user_id):

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -178,6 +178,7 @@ class RoleCreation(AdminView):
         return render_template("forms/admin/role_form.html",
                                **self.template_args())
 
+
 admin_blp = Blueprint('admin', 'admin', url_prefix='/admin')
 admin_blp.add_url_rule('/',
                        view_func=AdminView.as_view(

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -8,7 +8,46 @@ from sfa_dash.api_interface import (sites, observations, forecasts,
 from sfa_dash.blueprints.base import BaseView
 
 
-class PermissionsCreation(BaseView):
+class AdminView(BaseView):
+    subnav_format = {
+        '{users_url}': 'Users',
+        '{roles_url}': 'Roles',
+        '{permissions_url}': 'Permissions',
+    }
+
+
+    def template_args(self):
+        subnav_kwargs = {
+            'users_url': url_for('admin.users'),
+            'roles_url':url_for('admin.roles'),
+            'permissions_url':url_for('admin.permissions'),
+        }
+        return {'subnav': self.format_subnav(**subnav_kwargs)}
+
+    def get(self):
+        return render_template('forms/admin/admin.html',
+                               **self.template_args())
+
+
+class PermissionsListing(AdminView):
+    def get(self):
+        return render_template('forms/admin/permissions.html',
+                               **self.template_args())
+
+
+class RoleListing(AdminView):
+    def get(self):
+        return render_template('forms/admin/roles.html',
+                               **self.template_args())
+
+
+class UserListing(AdminView):
+    def get(self):
+        return render_template('forms/admin/users.html',
+                               **self.template_args())
+
+
+class PermissionsCreation(AdminView):
     allowed_data_types =['site', 'observation',
                          'forecast', 'cdf_forecast_group']
     def __init__(self, data_type):
@@ -30,49 +69,20 @@ class PermissionsCreation(BaseView):
         table_data = list_request.json()
         return render_template("forms/admin/permissions_form.html",
                                table_data=table_data,
-                               data_type=self.data_type)
+                               data_type=self.data_type,
+                               **self.template_args())
 
     def post(self):
         request.form
         return jsonify(request.form)
 
 
-class AdminView(BaseView):
-    subnav_format = {
-        '{users_url}': 'Users',
-        '{roles_url}': 'Roles',
-        '{permissions_url}': 'Permissions',
-    }
-
-
-    def template_args(self):
-        subnav_kwargs = {
-            'users_url': url_for('admin.users'),
-            'roles_url':url_for('admin.roles'),
-            'permissions_url':url_for('admin.permissions'),
-        }
-        return {'subnav': self.format_subnav(**subnav_kwargs)}
-
-
-class PermissionsListing(AdminView):
-    def get(self):
-        return render_template('forms/admin/permissions.html',
-                               **self.template_args())
-
-
-class RoleListing(AdminView):
-    def get(self):
-        return render_template('forms/admin/roles.html',
-                               **self.template_args())
-
-
-class UserListing(AdminView):
-    def get(self):
-        return render_template('forms/admin/users.html',
-                               **self.template_args())
-
-
 admin_blp = Blueprint('admin', 'admin', url_prefix='/admin')
+admin_blp.add_url_rule('/',
+                       view_func=AdminView.as_view(
+                            'admin')
+                       )
+                    
 admin_blp.add_url_rule('/permissions/',
                        view_func=PermissionsListing.as_view(
                             'permissions')    

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -1,0 +1,89 @@
+import json
+
+from flask import (Blueprint, render_template, request, jsonify,
+                   abort, redirect, url_for, make_response)
+import pandas as pd
+from sfa_dash.api_interface import (sites, observations, forecasts,
+                                    cdf_forecast_groups)
+from sfa_dash.blueprints.base import BaseView
+
+
+class PermissionsCreation(BaseView):
+    allowed_data_types =['site', 'observation',
+                         'forecast', 'cdf_forecast_group']
+    def __init__(self, data_type):
+        if data_type not in self.allowed_data_types:
+            raise ValueError('invalid data_type')
+        else:
+            if data_type == 'observation':
+                self.api_handle = observations
+            elif data_type == 'forecast':
+                self.api_handle = forecasts
+            elif data_type == 'site':
+                self.api_handle = sites
+            elif data_type == 'cdf_forecast_group':
+                self.api_handle = cdf_forecast_groups
+            self.data_type = data_type
+
+    def get(self):
+        list_request = self.api_handle.list_metadata()
+        table_data = list_request.json()
+        return render_template("forms/admin/permissions_form.html",
+                               table_data=table_data,
+                               data_type=self.data_type)
+
+    def post(self):
+        request.form
+        return jsonify(request.form)
+
+
+class AdminView(BaseView):
+    subnav_format = {
+        '{users_url}': 'Users',
+        '{roles_url}': 'Roles',
+        '{permissions_url}': 'Permissions',
+    }
+
+
+    def template_args(self):
+        subnav_kwargs = {
+            'users_url': url_for('admin.users'),
+            'roles_url':url_for('admin.roles'),
+            'permissions_url':url_for('admin.permissions'),
+        }
+        return {'subnav': self.format_subnav(**subnav_kwargs)}
+
+
+class PermissionsListing(AdminView):
+    def get(self):
+        return render_template('forms/admin/permissions.html',
+                               **self.template_args())
+
+
+class RoleListing(AdminView):
+    def get(self):
+        return render_template('forms/admin/roles.html',
+                               **self.template_args())
+
+
+class UserListing(AdminView):
+    def get(self):
+        return render_template('forms/admin/users.html',
+                               **self.template_args())
+
+
+admin_blp = Blueprint('admin', 'admin', url_prefix='/admin')
+admin_blp.add_url_rule('/permissions/',
+                       view_func=PermissionsListing.as_view(
+                            'permissions')    
+                       )
+for data_type in PermissionsCreation.allowed_data_types:
+    admin_blp.add_url_rule(f'/permissions/create/{data_type}',
+                           view_func=PermissionsCreation.as_view(
+                               f'{data_type}_permission',
+                               data_type=data_type)
+                           )
+admin_blp.add_url_rule('/roles/',
+                       view_func=RoleListing.as_view('roles'))
+admin_blp.add_url_rule('/users/',
+                       view_func=UserListing.as_view('users'))

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -1,9 +1,5 @@
-import pdb
-import json
-
 from flask import (Blueprint, render_template, request, jsonify,
-                   abort, redirect, url_for, make_response)
-import pandas as pd
+                   url_for)
 from sfa_dash.api_interface import (
     sites, observations, forecasts,
     cdf_forecast_groups, roles, users,
@@ -19,12 +15,11 @@ class AdminView(BaseView):
         '{permissions_url}': 'Permissions',
     }
 
-
     def template_args(self):
         subnav_kwargs = {
             'users_url': url_for('admin.users'),
-            'roles_url':url_for('admin.roles'),
-            'permissions_url':url_for('admin.permissions'),
+            'roles_url': url_for('admin.roles'),
+            'permissions_url': url_for('admin.permissions'),
         }
         return {'subnav': self.format_subnav(**subnav_kwargs)}
 
@@ -40,6 +35,8 @@ class PermissionsListing(AdminView):
         return render_template('forms/admin/permissions.html',
                                table_data=permissions_list,
                                **self.template_args())
+
+
 class PermissionView(AdminView):
     def get_api_handler(self, object_type):
         # The api interface should have a factory method to handle this logic
@@ -72,14 +69,18 @@ class PermissionView(AdminView):
             # dashboard uses singular object names as labels to differentiate
             # single views from listings
             object_type = permission['object_type'][:-1]
-            # create a dict of objects where keys are uuid and values are objects
+            # create a dict of objects where keys are uuid and values are
+            # objects
             objects = api_handler.list_metadata()
             object_list = objects.json()
-            object_map = {obj[f'{object_type}_id']:obj for obj in object_list}
-            # rebuild the 'objects' dict with the uuid: object structure instead
-            # of uuid: created_at
-            permission['objects'] = {k: {'added_to_permission':v, **object_map[k]}
-                                      for k,v in permission['objects'].items()}
+            object_map = {obj[f'{object_type}_id']: obj
+                          for obj in object_list}
+            # rebuild the 'objects' dict with the uuid: object structure
+            # instead of uuid: created_at
+            permission['objects'] = {
+                k: {'added_to_permission': v, **object_map[k]}
+                for k, v in permission['objects'].items()
+            }
         return render_template('forms/admin/permission.html',
                                permission=permission,
                                dashboard_type=object_type,
@@ -101,11 +102,14 @@ class RoleView(AdminView):
             role = None
         else:
             permission_list = permissions.list_metadata().json()
-            permission_map = {perm['permission_id']:perm for perm in permission_list}
-            role['permissions'] = {k: {'added_to_role':v, **permission_map[k]} for k,v in role['permissions'].items()}
+            permission_map = {perm['permission_id']: perm
+                              for perm in permission_list}
+            role['permissions'] = {k: {'added_to_role': v, **permission_map[k]}
+                                   for k, v in role['permissions'].items()}
         return render_template('forms/admin/role.html',
                                role=role,
                                **self.template_args())
+
 
 class UserListing(AdminView):
     def get(self):
@@ -122,17 +126,18 @@ class UserView(AdminView):
             user = None
         else:
             role_list = roles.list_metadata().json()
-            role_map = {role['role_id']:role for role in role_list}
-            user['roles'] = {k: {'added_to_user':v, **role_map[k]} for k,v in user['roles'].items()}
+            role_map = {role['role_id']: role for role in role_list}
+            user['roles'] = {k: {'added_to_user': v, **role_map[k]}
+                             for k, v in user['roles'].items()}
         return render_template('forms/admin/user.html',
                                user=user,
                                **self.template_args())
 
 
-
 class PermissionsCreation(AdminView):
-    allowed_data_types =['site', 'observation',
-                         'forecast', 'cdf_forecast_group']
+    allowed_data_types = ['site', 'observation',
+                          'forecast', 'cdf_forecast_group']
+
     def __init__(self, data_type):
         if data_type not in self.allowed_data_types:
             raise ValueError('invalid data_type')
@@ -163,12 +168,11 @@ class PermissionsCreation(AdminView):
 admin_blp = Blueprint('admin', 'admin', url_prefix='/admin')
 admin_blp.add_url_rule('/',
                        view_func=AdminView.as_view(
-                            'admin')
+                           'admin')
                        )
-                    
 admin_blp.add_url_rule('/permissions/',
                        view_func=PermissionsListing.as_view(
-                            'permissions')    
+                           'permissions')
                        )
 admin_blp.add_url_rule('/permissions/<uuid>',
                        view_func=PermissionView.as_view(

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -42,7 +42,7 @@ class DataTables(object):
             site_link = f'<a href={site_href}>{site_name}</a>'
             table_row['name'] = data['name']
             table_row['variable'] = data['variable']
-            table_row['provider'] = data.get('provider', 'Test User')
+            table_row['provider'] = data.get('provider', '')
             table_row['site'] = site_link
             if id_key == 'forecast_id':
                 table_row['link'] = url_for('data_dashboard.forecast_view',
@@ -145,7 +145,7 @@ class DataTables(object):
             site_link = f'<a href={site_href}>{site_name}</a>'
             table_row['name'] = data['name']
             table_row['variable'] = data['variable']
-            table_row['provider'] = data.get('provider', 'Test User')
+            table_row['provider'] = data.get('provider', '')
             table_row['site'] = site_link
             table_row['link'] = url_for(
                 'data_dashboard.cdf_forecast_group_view',
@@ -208,7 +208,7 @@ class DataTables(object):
         for data in data_list:
             table_row = {}
             table_row['name'] = data['name']
-            table_row['provider'] = data['provider']
+            table_row['provider'] = data.get('provider', '')
             table_row['latitude'] = data['latitude']
             table_row['longitude'] = data['longitude']
             table_row['link'] = url_for(link_view, uuid=data['site_id'])

--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -19,6 +19,7 @@ def api_to_dash_varname(api_varname):
 def api_varname_to_units(api_varname):
     return ALLOWED_VARIABLES[api_varname]
 
+
 def human_friendly_datatype(data_type):
     return data_type_mapping[data_type]
 

--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -3,6 +3,14 @@ from solarforecastarbiter.datamodel import ALLOWED_VARIABLES, COMMON_NAMES
 
 variable_mapping = COMMON_NAMES
 
+data_type_mapping = {
+    'site': 'Site',
+    'observation': 'Observation',
+    'forecast': 'Forecast',
+    'cdf_forecast': 'Probabilistic Forecast',
+    'cdf_forecast_group': 'Probabilistic Forecast Group',
+}
+
 
 def api_to_dash_varname(api_varname):
     return COMMON_NAMES[api_varname]
@@ -10,6 +18,9 @@ def api_to_dash_varname(api_varname):
 
 def api_varname_to_units(api_varname):
     return ALLOWED_VARIABLES[api_varname]
+
+def human_friendly_datatype(data_type):
+    return data_type_mapping[data_type]
 
 
 def display_timedelta(minutes):
@@ -54,3 +65,4 @@ def register_jinja_filters(app):
     app.jinja_env.filters['convert_varname'] = api_to_dash_varname
     app.jinja_env.filters['var_to_units'] = api_varname_to_units
     app.jinja_env.filters['display_timedelta'] = display_timedelta
+    app.jinja_env.filters['convert_data_type'] = human_friendly_datatype

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -257,3 +257,7 @@ a.help-button{
     font-weight: bold;
     padding: .75rem;
 }
+.scrollbox{
+    height: 400px;
+    overflow: scroll;
+}

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -2,6 +2,9 @@
 table.table th{
 	border-top: unset;
 }
+.table{
+    table-layout: fixed;
+}
 
 /* General css */
 

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -1,13 +1,17 @@
 /* Bootstrap overrides */
+
 table.table th{
 	border-top: unset;
 }
 table.table{
     table-layout: fixed;
 }
-.provider-column{
-    min-width: fit-content;
+@media (min-width: 992px){
+    table.results thead tr :first-child {
+        width: 40%;
+    }
 }
+
 
 /* General css */
 

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -2,8 +2,11 @@
 table.table th{
 	border-top: unset;
 }
-.table{
+table.table{
     table-layout: fixed;
+}
+.provider-column{
+    min-width: fit-content;
 }
 
 /* General css */

--- a/sfa_dash/static/js/table-checkall.js
+++ b/sfa_dash/static/js/table-checkall.js
@@ -1,0 +1,16 @@
+// Onclick functions to check/uncheck visible table rows
+// assumes the first td in each row contains a checkbox input
+$(document).ready(function(){
+    function setCheck(table_id, check_state) {
+        rows = Array.from($(table_id+' tbody tr[visible="true"]'));
+        rows.forEach(function(elem){
+            elem.cells[0].children[0].checked = check_state;
+        });
+    };
+    $('#check-button').click(function(){
+        setCheck('#permission-table', true);
+    });
+    $('#uncheck-button').click(function(){
+        setCheck('#permission-table', false);
+    });
+});

--- a/sfa_dash/templates/forms/admin/admin.html
+++ b/sfa_dash/templates/forms/admin/admin.html
@@ -1,0 +1,12 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'User and Permission Administration' %}
+{% block content %}
+<table class="table">
+<thead>
+
+</thead>
+<tbody>
+  
+</tbody>
+</table>
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/admin.html
+++ b/sfa_dash/templates/forms/admin/admin.html
@@ -1,12 +1,6 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'User and Permission Administration' %}
 {% block content %}
-<table class="table">
-<thead>
-
-</thead>
-<tbody>
-  
-</tbody>
-</table>
+<p>Placeholder administration landing page. Perhaps this is page contains help text, or maybe instead of
+a landing administrators are taken directly to the user page.</p>
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -16,8 +16,13 @@
         </ul>
     </div>
 </div>
-
-<table class="table">
+<h3>{{ permission['object_type'] | title }}</h3>
+<div class="tools {{ table_type }}-tools mt-1">
+   {% block tools %}
+   <input type="text" placeholder="Search" class="search">
+   {% endblock %}
+</div>
+<table class="object-table table results">
   <thead>
     <tr>
       <th scope="col">Object UUID</th>
@@ -25,10 +30,14 @@
     </tr>
   </thead>
   <tbody>
-    {% for obj, created in permission['objects'].items() %}
+    {% for uuid, obj in permission['objects'].items() %}
       <tr>
-        <td>{{ obj }}</td>
-        <td>{{ created }} </td>
+        {% if dashboard_type in ['role', 'permission', 'user']%}
+        <td><a href="{{ url_for('admin.'+dashboard_type+'_view', uuid=uuid) }}">{% if dashboard_type == 'permission' %}{{ obj['description'] }}{% elif dashboard_type == 'user'%}{{ obj['user_id'] }}{% else %}{{ obj['name'] }}{% endif %} </a></td>
+        {% else %}
+        <td><a href="{{ url_for('data_dashboard.'+dashboard_type+'_view', uuid=uuid) }}">{{ obj['name'] }}</a></td>
+        {% endif %}
+        <td>{{ obj['added_to_permission'] }} </td>
       </tr>
 
     {% endfor %}

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -1,7 +1,7 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Permissions' %}
 {% block content %}
-{% if permission is defined %}
+{% if permission is not none %}
 <div class="data-metadata border mt-2">
     <h3>Permission Data</h3>
     <div class="row">
@@ -25,8 +25,8 @@
 <table class="object-table table results">
   <thead>
     <tr>
-      <th scope="col">Object UUID</th>
-      <th scope="col">Date Added</th>
+      <th scope="col">Name</th>
+      <th scope="col">Date Added to Permission</th>
     </tr>
   </thead>
   <tbody>
@@ -43,5 +43,7 @@
     {% endfor %}
   </tbody>
 </table>
+{% else %}
+<p>404 Not Found</p>
 {% endif %}
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -1,0 +1,38 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'Permissions' %}
+{% block content %}
+{% if permission is defined %}
+<div class="data-metadata border mt-2">
+    <h3>Permission Data</h3>
+    <div class="row">
+        <ul class="data-metadata-fields col-md-6 col-xs-12">
+            <li><b>Description:</b> {{ permission['description'] }}</li>
+            <li><b>Action:</b> {{ permission['action'] }}</li>
+            <li><b>Object Type:</b> {{ permission['object_type'] }}</li>
+            <li><b>Organization:</b> {{ permission['organization'] }} </li>
+        </ul>
+        <ul class="data-metadata-fields col-md-6 col-xs-12">
+            <li><b>Created:</b> {{ permission['created_at'] }}</li>
+        </ul>
+    </div>
+</div>
+
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Object UUID</th>
+      <th scope="col">Date Added</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for obj, created in permission['objects'].items() %}
+      <tr>
+        <td>{{ obj }}</td>
+        <td>{{ created }} </td>
+      </tr>
+
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/permission_macros.jinja
+++ b/sfa_dash/templates/forms/admin/permission_macros.jinja
@@ -1,0 +1,22 @@
+{% macro data_row(data_type, row_values) %}
+{% if data_type == 'observation' %}
+  {% set uuid = row_values['observation_id'] %}
+{% else %}
+  {% set uuid = row_values['forecast_id'] %}
+{% endif %}
+<tr visible="true">
+  <td><input type="checkbox" name="objects-list" value="{{ uuid }}"></td>
+  <td>{{ row_values['name'] }}</td>
+  <td>{{ row_values['variable'] | convert_varname }}</td>
+  <td>{{ uuid }}</td>
+</tr> 
+{% endmacro %}
+
+{% macro site_row(data_type, row_values) %}
+{% set uuid = row_values['site_id'] %}
+<tr visible="true">
+  <td><input type="checkbox" name="objects-list" value="{{ uuid }}"></td>
+  <td>{{ row_values['name'] }}</td>
+  <td>{{ uuid }}</td>
+</tr>
+{% endmacro %}

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -9,7 +9,13 @@
   <a class="btn-sm btn-primary" href='{{ url_for("admin.site_permission") }}'>Sites</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
 </div>
-<table class="table">
+<h3>Existing Permissions</h3>
+<div class="tools {{ table_type }}-tools mt-1">
+  {% block tools %}
+    <input type="text" placeholder="Search" class="search">
+  {% endblock %}
+</div>
+<table class="permissions-table table results">
   <thead>
     <tr>
       <th scope="col">Description</th>

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -1,0 +1,8 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'Permissions' %}
+{% block content %}
+<a href="{{ url_for('admin.observation_permission') }}">Observations</a>
+<a href='{{ url_for("admin.forecast_permission") }}'>Forecasts</a>
+<a href='{{ url_for("admin.site_permission") }}'>Sites</a>
+<a href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -1,6 +1,7 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Permissions' %}
 {% block content %}
+{# Commented out non-functioning links for esig demo
 <div class="data-metadata border mt-2">
   <h3>Create a new permission</h3>
   Select a data type:
@@ -9,6 +10,7 @@
   <a class="btn-sm btn-primary" href='{{ url_for("admin.site_permission") }}'>Sites</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
 </div>
+#}
 <h3>Existing Permissions</h3>
 <div class="tools {{ table_type }}-tools mt-1">
   {% block tools %}

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -1,8 +1,12 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Permissions' %}
 {% block content %}
-<a href="{{ url_for('admin.observation_permission') }}">Observations</a>
-<a href='{{ url_for("admin.forecast_permission") }}'>Forecasts</a>
-<a href='{{ url_for("admin.site_permission") }}'>Sites</a>
-<a href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
+<div class="data-metadata border mt-2">
+  <h3>Create a new permission</h3>
+  Select a data type:
+  <a class="btn-sm btn-primary" href="{{ url_for("admin.observation_permission") }}">Observation</a>
+  <a class="btn-sm btn-primary" href='{{ url_for("admin.forecast_permission") }}'>Forecasts</a>
+  <a class="btn-sm btn-primary" href='{{ url_for("admin.site_permission") }}'>Sites</a>
+  <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
+</div>
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -9,4 +9,27 @@
   <a class="btn-sm btn-primary" href='{{ url_for("admin.site_permission") }}'>Sites</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
 </div>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Description</th>
+      <th scope="col">Action</th>
+      <th scope="col">Object Type</th>
+      <th scope="col">Applies to all</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if table_data is defined %}
+      {% for perm in table_data %}
+        <tr>
+            <td><a href="{{ url_for('admin.permission_view', uuid=perm['permission_id'])}}">{{ perm["description"] }}</a></td>
+            <td>{{ perm["action"] }}</td>
+            <td>{{ perm["object_type"] }} </td>
+
+            <td>{% if perm["applies_to_all"] %}&#10004;{% endif %} </td>
+        </tr>
+      {% endfor %}
+    {% endif %}
+  </tbody>
+</table>
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/permissions_form.html
+++ b/sfa_dash/templates/forms/admin/permissions_form.html
@@ -1,0 +1,73 @@
+{% extends "forms/base/base_form.html" %}
+{% import "forms/admin/permission_macros.jinja" as table_macros %}
+{% set page_title = 'Create New Permission' %}
+{% if data_type is not defined %}
+  {% set data_type="observation" %}
+{% endif %}
+{% if table_data is not defined %}
+  {% set table_data={} %}
+{% endif %}
+{% if data_type == 'site' %}
+  {% set row_macro = table_macros.site_row %}
+{% else %}
+{% set row_macro = table_macros.data_row %}
+{% endif %}
+{% block fields %}
+<p>Creating a new permission for data of type '{{ data_type | convert_data_type}}'.</p>
+<div class="form-element full-width">
+  <label>Description</label><br/>
+  <input type="text" class="form-control" name="description">
+</div>
+<div class="form-element full-width">
+  <label>Action</label><br/>
+  <p>Select the action this permission will allow.</p>
+  <input type="radio" name="action" value="create" required>Create
+  <input type="radio" name="action" value="read">Read
+  {# <input type="radio" name="action" value="update">Update #}
+  <input type="radio" name="action" value="delete">Delete
+  {% if data_type != "site" %}
+  <input type="radio" name="action" value="read_values">Read Values
+  <input type="radio" name="action" value="write_values">Write Values
+  <input type="radio" name="action" value="delete_values">Delete Values
+  {% endif %}
+</div>
+<div class="form-element full-width">
+  <label>Applies to all</label>
+  <input type="checkbox" name="applies-to-all" data-toggle="collapse" data-target="#object-selector">
+  <p>Check to allow the action on all {{ data_type }} in your organization.</p>
+</div>
+<div class="form-element full-width collapse show" id="object-selector">
+  <div class="permissions-object-table">
+    <label>{{ data_type | convert_data_type }}s</label>
+    <p>Select the {{ data_type | convert_data_type}}s to allow the action on.</p>
+    <div class="tools permissions-objects-table mt-1">
+      <input type="text" placeholder="Search" class="search">
+      <button type='button' class="btn-sm btn-primary mt-1" id='check-button'>Check All</button>
+      <button type='button' class="btn-sm btn-primary mt-1" id='uncheck-button'>Uncheck All</button>
+    </div>
+    <div class="scrollbox">
+      <table class="table results" id='permission-table'>
+        <thead>
+          <th scope="col"></th>
+          <th scope="col">Name</th>
+          {% if data_type != 'site' %}
+          <th scope="col">Variable</th>
+          {% endif %}
+          <th scope="col">UUID</th>
+        </thead>
+        <tbody>
+          <tr class="warning no-result">
+            <td collspan="3">
+              <i class="fa fa-warning"></i>
+              No Result
+            </td>
+          </tr> 
+          {% for row in table_data %}
+          {{ row_macro(data_type, row) }}
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -16,7 +16,13 @@
         </ul>
     </div>
 </div>
-<table class="table">
+<h3>Permissions</h3>
+<div class="tools {{ table_type }}-tools mt-1">
+   {% block tools %}
+   <input type="text" placeholder="Search" class="search">
+   {% endblock %}
+</div>
+<table class="role-permissions-table table results">
   <thead>
     <tr>
       <th scope="col">Permission ID</th>

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -1,0 +1,36 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'Roles' %}
+{% block content %}
+{% if role is defined %}
+<div class="data-metadata border mt-2">
+    <h3>Role Data</h3>
+    <div class="row">
+        <ul class="data-metadata-fields col-md-6 col-xs-12">
+            <li><b>Name:</b> {{ role['name'] }}</li>
+            <li><b>Description:</b> {{ role['description'] }}</li>
+            <li><b>Organization:</b> {{ role['organization'] }} </li>
+        </ul>
+        <ul class="data-metadata-fields col-md-6 col-xs-12">
+            <li><b>Created:</b> {{ role['created_at'] }}</li>
+            <li><b>Last Modified:</b> {{ role['modified_at'] }}</li>
+        </ul>
+    </div>
+</div>
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Permission ID</th>
+      <th scope="col">Date Added</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for perm_id, perm in role['permissions'].items() %}
+      <tr>
+          <td><a href="{{ url_for('admin.permission_view', uuid=perm_id) }}">{{ perm['description'] }}</a></td>
+          <td>{{ perm['added_to_role'] }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -1,7 +1,7 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Roles' %}
 {% block content %}
-{% if role is defined %}
+{% if role is not none %}
 <div class="data-metadata border mt-2">
     <h3>Role Data</h3>
     <div class="row">
@@ -25,8 +25,8 @@
 <table class="role-permissions-table table results">
   <thead>
     <tr>
-      <th scope="col">Permission ID</th>
-      <th scope="col">Date Added</th>
+      <th scope="col">Name</th>
+      <th scope="col">Date Added to Role</th>
     </tr>
   </thead>
   <tbody>
@@ -38,5 +38,7 @@
     {% endfor %}
   </tbody>
 </table>
+{% else %}
+<p>404 Not Found</p>
 {% endif %}
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/roles.html
+++ b/sfa_dash/templates/forms/admin/roles.html
@@ -1,7 +1,13 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Roles' %}
 {% block content %}
-<table class="table">
+<h3>Existing Roles</h3>
+<div class="tools {{ table_type }}-tools mt-1">
+  {% block tools %}
+    <input type="text" placeholder="Search" class="search">
+  {% endblock %}
+</div>
+<table class="roles-table table results">
   <thead>
     <tr>
       <th scope="col">Name</th>

--- a/sfa_dash/templates/forms/admin/roles.html
+++ b/sfa_dash/templates/forms/admin/roles.html
@@ -12,7 +12,9 @@
     <tr>
       <th scope="col">Name</th>
       <th scope="col">Description</th>
-      <th scope="col">Organization</th>
+      <th scope="col" id="provider-header">
+        <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -20,7 +22,7 @@
         <tr>
             <td><a href="{{ url_for('admin.role_view', uuid=role['role_id']) }}">{{ role["name"] }}</a></td>
             <td>{{ role["description"] }}</td>
-            <td>{{ role["organization"] }} </td>
+            <td class="provider-column">{{ role["organization"] }} </td>
         </tr>
       {% endfor %}
   </tbody>

--- a/sfa_dash/templates/forms/admin/roles.html
+++ b/sfa_dash/templates/forms/admin/roles.html
@@ -1,0 +1,5 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'Roles' %}
+{% block content %}
+Roles n stuff.
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/roles.html
+++ b/sfa_dash/templates/forms/admin/roles.html
@@ -1,5 +1,22 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Roles' %}
 {% block content %}
-Roles n stuff.
+<table class="table">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Description</th>
+      <th scope="col">Organization</th>
+    </tr>
+  </thead>
+  <tbody>
+      {% for role in table_data %}
+        <tr>
+            <td><a href="{{ url_for('admin.role_view', uuid=role['role_id']) }}">{{ role["name"] }}</a></td>
+            <td>{{ role["description"] }}</td>
+            <td>{{ role["organization"] }} </td>
+        </tr>
+      {% endfor %}
+  </tbody>
+</table>
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -1,0 +1,41 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'Users' %}
+{% block content %}
+{% if user is not none %}
+<div class="data-metadata border mt-2">
+    <h3>User Data</h3>
+    <div class="row">
+        <ul class="data-metadata-fields col-md-6 col-xs-12">
+            <li><b>ID:</b> {{ user['user_id'] }}</li>
+            <li><b>Organization:</b> {{ user['organization'] }} </li>
+        </ul>
+        <ul class="data-metadata-fields col-md-6 col-xs-12">
+        </ul>
+    </div>
+</div>
+<h3>Roles</h3>
+<div class="tools {{ table_type }}-tools mt-1">
+   {% block tools %}
+   <input type="text" placeholder="Search" class="search">
+   {% endblock %}
+</div>
+<table class="user-roles-table table results">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Date Added</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for role_id, role in user['roles'].items() %}
+      <tr>
+          <td><a href="{{ url_for('admin.role_view', uuid=role_id) }}">{{ role['name'] }}</a></td>
+          <td>{{ role['added_to_user'] }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p>404 Not Found </p>
+{% endif %}
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -8,7 +8,7 @@
         <ul class="data-metadata-fields col-md-6 col-xs-12">
             <li><b>ID:</b> {{ user['user_id'] }}</li>
             <li><b>Email:</b> notyetimplemented@solarforecastarbiter.org</li>
-            <li><b>Organization:</b> {{ user['organization'] }} </li>
+            <li ><b>Organization:</b> {{ user['organization'] }} </li>
         </ul>
         <ul class="data-metadata-fields col-md-6 col-xs-12">
             <li><b>Created:</b> {{user['created_at']}}</li>
@@ -26,7 +26,9 @@
   <thead>
     <tr>
       <th scope="col">Name</th>
-      <th scope="col">Organization</th>
+      <th scope="col" id="provider-header">
+          <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
+      </th>
       <th scope="col">Date Added</th>
     </tr>
   </thead>

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -7,6 +7,7 @@
     <div class="row">
         <ul class="data-metadata-fields col-md-6 col-xs-12">
             <li><b>ID:</b> {{ user['user_id'] }}</li>
+            <li><b>Email:</b> notyetimplemented@solarforecastarbiter.org</li>
             <li><b>Organization:</b> {{ user['organization'] }} </li>
         </ul>
         <ul class="data-metadata-fields col-md-6 col-xs-12">

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -10,6 +10,8 @@
             <li><b>Organization:</b> {{ user['organization'] }} </li>
         </ul>
         <ul class="data-metadata-fields col-md-6 col-xs-12">
+            <li><b>Created:</b> {{user['created_at']}}</li>
+            <li><b>Last Modified:</b> {{user['modified_at']}}</li>
         </ul>
     </div>
 </div>

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -25,6 +25,7 @@
   <thead>
     <tr>
       <th scope="col">Name</th>
+      <th scope="col">Organization</th>
       <th scope="col">Date Added</th>
     </tr>
   </thead>
@@ -32,6 +33,7 @@
     {% for role_id, role in user['roles'].items() %}
       <tr>
           <td><a href="{{ url_for('admin.role_view', uuid=role_id) }}">{{ role['name'] }}</a></td>
+          <td>{{ role['organization'] }}</td>
           <td>{{ role['added_to_user'] }}</td>
       </tr>
     {% endfor %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -12,7 +12,9 @@
     <tr>
       <th scope="col">User ID</th>
       <th scope="col">Email</th>
-      <th scope="col">Organization</th>
+      <th scope="col" id="provider-header">
+        <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -21,7 +23,7 @@
         <tr>
             <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["user_id"] }}</a></td>
             <td>&lt;email coming soon&gt;</td>
-            <td>{{ user["organization"] }} </td>
+            <td class="provider-column">{{ user["organization"] }} </td>
         </tr>
       {% endfor %}
     {% endif %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -1,0 +1,12 @@
+{% extends "dash/data.html" %}
+{% set page_title = 'Users' %}
+{% block content %}
+<table class="table">
+<thead>
+
+</thead>
+<tbody>
+  
+</tbody>
+</table>
+{% endblock %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -11,6 +11,7 @@
   <thead>
     <tr>
       <th scope="col">User ID</th>
+      <th scope="col">Username</th>
       <th scope="col">Organization</th>
     </tr>
   </thead>
@@ -19,6 +20,7 @@
       {% for user in table_data %}
         <tr>
             <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["user_id"] }}</a></td>
+            <td>&lt;usernames coming soon&gt;</td>
             <td>{{ user["organization"] }} </td>
         </tr>
       {% endfor %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -11,7 +11,7 @@
   <thead>
     <tr>
       <th scope="col">User ID</th>
-      <th scope="col">Username</th>
+      <th scope="col">Email</th>
       <th scope="col">Organization</th>
     </tr>
   </thead>
@@ -20,7 +20,7 @@
       {% for user in table_data %}
         <tr>
             <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["user_id"] }}</a></td>
-            <td>&lt;usernames coming soon&gt;</td>
+            <td>&lt;email coming soon&gt;</td>
             <td>{{ user["organization"] }} </td>
         </tr>
       {% endfor %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -2,11 +2,21 @@
 {% set page_title = 'Users' %}
 {% block content %}
 <table class="table">
-<thead>
-
-</thead>
-<tbody>
-  
-</tbody>
+  <thead>
+    <tr>
+      <th scope="col">User ID</th>
+      <th scope="col">Organization</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% if table_data is defined %}
+      {% for role in table_data %}
+        <tr>
+            <td>{{ role["user_id"] }}</td>
+            <td>{{ role["organization"] }} </td>
+        </tr>
+      {% endfor %}
+    {% endif %}
+  </tbody>
 </table>
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -16,10 +16,10 @@
   </thead>
   <tbody>
     {% if table_data is defined %}
-      {% for role in table_data %}
+      {% for user in table_data %}
         <tr>
-            <td>{{ role["user_id"] }}</td>
-            <td>{{ role["organization"] }} </td>
+            <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["user_id"] }}</a></td>
+            <td>{{ user["organization"] }} </td>
         </tr>
       {% endfor %}
     {% endif %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -1,7 +1,13 @@
 {% extends "dash/data.html" %}
 {% set page_title = 'Users' %}
 {% block content %}
-<table class="table">
+<h3>Existing Users</h3>
+<div class="tools {{ table_type }}-tools mt-1">
+  {% block tools %}
+    <input type="text" placeholder="Search" class="search">
+  {% endblock %}
+</div>
+<table class="users-table table results">
   <thead>
     <tr>
       <th scope="col">User ID</th>

--- a/sfa_dash/templates/forms/base/base_form.html
+++ b/sfa_dash/templates/forms/base/base_form.html
@@ -1,0 +1,13 @@
+{% import "forms/form_macros.jinja" as form %}
+{% extends "dash/data.html" %}
+{% block content %}
+{% include "sections/notifications.html" %}
+<form action="" method="post" enctype="application/json" id="the-form-id">
+  <div class="form-group">
+    {% block fields %}
+    {% endblock %}
+    {{ form.token() }}
+  </div>
+</form>
+<button type="submit" form="the-form-id" value="Submit" class="btn btn-primary">Submit</button>
+{% endblock %}

--- a/sfa_dash/templates/navbar.html
+++ b/sfa_dash/templates/navbar.html
@@ -27,6 +27,7 @@
             <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
               {% if user is not none %}
               <div class= "dropdown-item"><b>Logged in as:</b><br/> {{ user['name'] }}</div>
+              <a class="dropdown-item" href="{{ url_for('admin.admin') }}">User Administration</a>
               <a class="dropdown-item" href="{{ url_for('logout') }}">Log out</a>
               {% else %}
               <a class="dropdown-item" href="{{ url_for('auth0.login') }}">Log in</a>


### PR DESCRIPTION
Basic User administration layout.
This PR adds a user administration seciton accessible from the 'Account' link in the upper right corner of the dashboard. It contains the following sections:

- User listing:  Displays users an administrator has access to. At the moment, this is currently just the Test User, who is also the only user in the organization. The /users/ endpoint only returns uuid, organization, created at and modified, so I used UUIDS in this version of the table.
![user_listing](https://user-images.githubusercontent.com/21206164/58577861-4754eb00-81fc-11e9-9618-08209b73fb8a.png)

- User page: Displays user metadata and roles. Roles are listed by name and date added to the user.
![user_view](https://user-images.githubusercontent.com/21206164/58577880-58056100-81fc-11e9-9224-beb4d5a3d69f.png)

- Role Listing: displays roles an administrator has access to. Lists name description and organization of the role. Note that an administrator might have access to view a role from another organization and view the permissions associated with it, but may not edit the role.
![role_listing](https://user-images.githubusercontent.com/21206164/58577965-87b46900-81fc-11e9-9c21-2922d2a9021f.png)

- Role View: Display Role Metadata and permissions permissions are listed by their description and the date added to the Role.
![role_view](https://user-images.githubusercontent.com/21206164/58578021-a9155500-81fc-11e9-9931-cb163dfa6643.png)

- Permission Listing: Lists all permissions administrator has access to. Lists description, action, object_type and the applies_to_all for each permission. 
![permission_listing](https://user-images.githubusercontent.com/21206164/58578301-55573b80-81fd-11e9-9a41-c24b970580ae.png)

- Permission View: Displays metadata of the permission and the objects it allows access to. Perhaps if the permission has the `applies_to_all` flag set, objects should be hidden.
![permission_view](https://user-images.githubusercontent.com/21206164/58578392-89caf780-81fd-11e9-9262-ebcb3a4ea524.png)

These pages work with the users/permissions/roles endpoints added to the api, but the code is rudimentary and meant to showcase user interface more than provide a robust backend. 
