### PR TITLE
correct use of first-child selector

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -7,7 +7,7 @@ table.table{
     table-layout: fixed;
 }
 @media (min-width: 992px){
-    table.results thead tr :first-child {
+    table.results thead tr th:first-child {
         width: 40%;
     }
 }


### PR DESCRIPTION
The first-child selector I setup was too generic, and spilling over into the filter `<ul>` in the table header. 