### PR TITLE
Fix download datetime field errors

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -215,6 +215,7 @@ span.help-text::before {
 ul.error-list, ul.message-list{
   list-style: none;
   margin-top: .5rem;
+  padding-left: 0;
 }
 li.alert{
   margin-bottom: .5rem;

--- a/sfa_dash/templates/forms/base/download_form.html
+++ b/sfa_dash/templates/forms/base/download_form.html
@@ -6,7 +6,26 @@
 {% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
 <form action="{{ url_for('forms.download_' + data_type + '_data', uuid=uuid) }}" method="post"  id="{{ data_type }}-download">
   <div class="form-group">
-    {% block fields %}
+    <div class="form-element">
+      <label for="start">Start (UTC):</label>
+      <input type="date" id="start-date" name="period-start-date" {% if form_data is defined %}value="{{form_data['period-start-date']}}"{% endif %}required>
+      <input type="time" id="start-time" name="period-start-time" {% if form_data is defined %}value="{{form_data['period-start-time']}}"{% else %} value="00:00"{% endif %} required>
+    </div>
+    <div class="form-element">
+      <label for="end">End (UTC):</label>
+      <input type="date" id="end-date" name="period-end-date" {% if form_data is defined %}value="{{form_data['period-end-date']}}"{% endif %}required>
+      <input type="time" id="end-time" name="period-end-time" {% if form_data is defined %}value="{{form_data['period-end-time']}}"{% else %} value="00:00"{% endif %} required>
+    </div>
+    <div class="form-element full-width">
+      <label for="format">Format</label><br/>
+      <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
+      <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
+    </div>
+    {% block example %}
+	  {# block should contain the following divs to be collapsed by the radio buttons above #}
+	  <div class="form-element full-width">
+  		<div class="download-example csv show"></div>
+		<div class="download=example json collapse"></div>
     {% endblock %}
     {{ form.token() }}
   </div>

--- a/sfa_dash/templates/forms/cdf_forecast_download_form.html
+++ b/sfa_dash/templates/forms/cdf_forecast_download_form.html
@@ -1,20 +1,7 @@
 {% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Forecast data' %}
 {% set data_type = 'cdf_forecast' %}
-{% block fields %}
-<div class="form-element">
-  <label for="start">Start time:</label>
-  <input type="datetime-local" id="start" name="period-start">
-</div>
-<div class="form-element">
-  <label for="end">End time:</label>
-  <input type="datetime-local" id="end" name="period-end">
-</div>
-<div class="form-element full-width">
-  <label for="format">Format</label><br/>
-  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
-  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
-</div>
+{% block example %}
 <div class="form-element full-width">
   <div class="download-example csv show">
   <p>CSV downloads will have the following format.</p>

--- a/sfa_dash/templates/forms/forecast_download_form.html
+++ b/sfa_dash/templates/forms/forecast_download_form.html
@@ -1,20 +1,7 @@
 {% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Forecast data' %}
 {% set data_type = 'forecast' %}
-{% block fields %}
-<div class="form-element">
-  <label for="start">Start time:</label>
-  <input type="datetime-local" id="start" name="period-start">
-</div>
-<div class="form-element">
-  <label for="end">End time:</label>
-  <input type="datetime-local" id="end" name="period-end">
-</div>
-<div class="form-element full-width">
-  <label for="format">Format</label><br/>
-  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
-  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
-</div>
+{% block example %}
 <div class="form-element full-width">
   <div class="download-example csv show">
   <p>CSV downloads will have the following format.</p>

--- a/sfa_dash/templates/forms/observation_download_form.html
+++ b/sfa_dash/templates/forms/observation_download_form.html
@@ -1,20 +1,7 @@
 {% extends "forms/base/download_form.html" %}
 {% set page_title = 'Download Observation data' %}
 {% set data_type = 'observation' %}
-{% block fields %}
-<div class="form-element">
-  <label for="start">Start time:</label>
-  <input type="datetime-local" id="start" name="period-start">
-</div>
-<div class="form-element">
-  <label for="end">End time:</label>
-  <input type="datetime-local" id="end" name="period-end">
-</div>
-<div class="form-element full-width">
-  <label for="format">Format</label><br/>
-  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="text/csv" checked>CSV</input>
-  <input type="radio" data-toggle="collapse" data-target=".download-example" name="format" value="application/json">JSON</input>
-</div>
+{% block example %}
 <div class="form-element full-width">
   <div class="download-example csv show">
   <p>CSV downloads will have the following format.</p>


### PR DESCRIPTION
closes #83 
datetime-local input type support isn't great. So this PR splits this into separate date and time fields, which should have better support. It also adds error handling for if the fields aren't supported and some garbage input is allowed.
Added UTC to the field labels to clarify timezone of the input. 
The new UI should look like this and be more consistend across browsers.
![Screenshot from 2019-06-04 12-10-16](https://user-images.githubusercontent.com/21206164/58906850-bed5bf00-86c1-11e9-8743-5bc8a708508c.png)
