### PR TITLE
Layout fixes

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -21,13 +21,26 @@ html{
 body{
   color: #333;
 }
-main{
-  margin-top: 11rem;
-  // margin-top: 7rem;
+main { 
   margin-bottom: 2rem;
+}
+@media (min-width: 768px){
+  main{
+    margin-top: 11rem;
+  }
+}
+@media (max-width: 767px){
+  main{
+    margin-top: 12rem;
+  }
 }
 .menu-list{
   list-style: none;
+}
+@media (min-width: 768px){
+  div.sidebar-wrapper {
+    border-right: 1px solid #dee2e6!important;
+  }
 }
 ul.sidebar-menu{
   padding-left: 0; 
@@ -170,7 +183,6 @@ ul.data-metadata-fields{
   width: 100%;
 }
 .time-field{
-  width: unset;
   display: inline-block;
 }
 .form-element .well-known-text-field{

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -274,6 +274,23 @@ a.help-button{
     border-radius: 5px;
     padding: .5rem;
 }
+#org-filter-collapse{
+    font-family: monospace;
+    color: #000;
+    border: 1px solid black;
+    border-radius: 3px;
+    margin-left: 1rem;
+    padding: .1rem 0.3rem;
+}
+#org-filter-collapse:hover{
+    text-decoration: none;
+    background-color: #ddd;
+    transition: background-color .2s;
+}
+#org-filter-collapse:after{
+    content: "\00d7";
+    font-size: 1rem;
+}
 .org-filter-options{
     list-style: none;
     padding-left: 0;

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -159,6 +159,7 @@ ul.data-metadata-fields{
 
 /* Forms */
 .form-group{
+  width: 100%;
   float: left;
 }
 .form-element label{

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -1,5 +1,20 @@
 /* Bootstrap overrides */
-
+@media (min-width: 768px){
+  .fixed-top{
+    position: fixed;
+  }
+}
+@media (max-width: 767px){
+  .fixed-top{
+    position: relative;
+  }
+}
+.fixed-top{
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1030;
+}
 table.table th{
   border-top: unset;
 }
@@ -31,7 +46,7 @@ main {
 }
 @media (max-width: 767px){
   main{
-    margin-top: 12rem;
+    margin-top: 0;
   }
 }
 .menu-list{

--- a/sfa_dash/static/js/filter_column.js
+++ b/sfa_dash/static/js/filter_column.js
@@ -2,22 +2,26 @@
  * class and creates a drop-down list of checkboxes for hiding table rows by organizaiton
  */
 $(document).ready(function() {
-    var availableOrgs = new Set([]);
-    var orgs = $(".provider-column");
-    for (i = 0; i < orgs.length; i++) {
-        availableOrgs.add(orgs[i].textContent);
-    }
-    var filter_div = $("<div id='org-filters' class='collapse'>Filter by Organization <a href='#' role='button' id='org-filter-collapse'>X</a><br/><hr><ul class='org-filter-options'></ul></div>");
-    filter_div.appendTo("#provider-header");
-    availableOrgs.forEach(function (e) {$(".org-filter-options").append(`<li><input class="org-filter-option"value="${e}" type="checkbox" checked>${e}</li>`)});
-    
-    $(".org-filter-option").change(function() {
-        console.log(`${this.checked}`);
-        console.log(` content: ${this.value}`);
-        if (this.checked) {
-            $(`.provider-column:contains("${this.value}")`).parent().show();
-        } else {
-           $(`.provider-column:contains("${this.value}")`).parent().hide();
+    if ($('#provider-header').length){
+        var availableOrgs = new Set([]);
+        var orgs = $(".provider-column");
+        for (i = 0; i < orgs.length; i++) {
+            availableOrgs.add(orgs[i].textContent);
         }
-    });
+        var filter_div = $("<div id='org-filters' class='collapse'>Filter by Organization <a href='#' role='button' id='org-filter-collapse'></a><br/><hr><ul class='org-filter-options'></ul></div>");
+        filter_div.appendTo("#provider-header");
+        availableOrgs.forEach(function (e) {$(".org-filter-options").append(`<li><input class="org-filter-option"value="${e}" type="checkbox" checked>${e}</li>`)});
+        $('#org-filter-collapse').click(function() {
+            $('#org-filters').collapse('toggle');
+        });
+        $(".org-filter-option").change(function() {
+            console.log(`${this.checked}`);
+            console.log(` content: ${this.value}`);
+            if (this.checked) {
+                $(`.provider-column:contains("${this.value}")`).parent().show();
+            } else {
+               $(`.provider-column:contains("${this.value}")`).parent().hide();
+            }
+        });
+    }
 });

--- a/sfa_dash/static/js/filter_column.js
+++ b/sfa_dash/static/js/filter_column.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
     for (i = 0; i < orgs.length; i++) {
         availableOrgs.add(orgs[i].textContent);
     }
-    var filter_div = $("<div id='org-filters' class='collapse'>Filter by Organization <br/><hr><ul class='org-filter-options'></ul></div>");
+    var filter_div = $("<div id='org-filters' class='collapse'>Filter by Organization <a href='#' role='button' id='org-filter-collapse'>X</a><br/><hr><ul class='org-filter-options'></ul></div>");
     filter_div.appendTo("#provider-header");
     availableOrgs.forEach(function (e) {$(".org-filter-options").append(`<li><input class="org-filter-option"value="${e}" type="checkbox" checked>${e}</li>`)});
     

--- a/sfa_dash/templates/base.html
+++ b/sfa_dash/templates/base.html
@@ -20,7 +20,7 @@
             {% endif %}
 			{% if sidebar %}
 		    {% include "sidebar.html" %} 
-		    <div class="content col-sm-9 col-xs-12">
+		    <div class="content col-md-9 col-sm-12">
 			{% else %}
 			<div class="content col-md-12">
 			{% endif %}

--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -4,11 +4,11 @@
 {% extends "data/metadata/meta_container.html" %}
 {% import "data/metadata/meta_macro.jinja" as macro %}
 {% block metadata %}
-<ul class="data-metadata-fields col-md-6 col-xs-12">
+<ul class="data-metadata-fields col-md-6 col-sm-12">
       {{ macro.li('Name', name) }}
       {{ macro.li('Site', site_link )}}
 </ul>
-<ul class="data-metadata-fields col-md-6 col-xs-12">
+<ul class="data-metadata-fields col-md-6 col-sm-12">
   {{ macro.li('Variable', variable |convert_varname, variable | var_to_units) }}
   {{ macro.li('Value type', interval_value_type) }}
   {{ macro.li('Interval label', interval_label) }}

--- a/sfa_dash/templates/data/metadata/forecast_metadata.html
+++ b/sfa_dash/templates/data/metadata/forecast_metadata.html
@@ -4,7 +4,7 @@
 {% set data_type = 'Forecast' %}
 {% endif %}
 {% block extra_fields %}
-{{ macro.li('Issue time of day', issue_time_of_day) }}
+{{ macro.li('Issue time of day', issue_time_of_day+'Z') }}
 {{ macro.li('Run length / Issue frequency', run_length | display_timedelta) }}
 {{ macro.li('Lead time to start', lead_time_to_start | display_timedelta) }}
 {# 

--- a/sfa_dash/templates/forms/base/download_form.html
+++ b/sfa_dash/templates/forms/base/download_form.html
@@ -7,12 +7,12 @@
 <form action="{{ url_for('forms.download_' + data_type + '_data', uuid=uuid) }}" method="post"  id="{{ data_type }}-download">
   <div class="form-group">
     <div class="form-element">
-      <label for="start">Start (UTC):</label>
+      <label for="start">Start (UTC):</label><br/>
       <input type="date" id="start-date" name="period-start-date" {% if form_data is defined %}value="{{form_data['period-start-date']}}"{% endif %}required>
       <input type="time" id="start-time" name="period-start-time" {% if form_data is defined %}value="{{form_data['period-start-time']}}"{% else %} value="00:00"{% endif %} required>
     </div>
     <div class="form-element">
-      <label for="end">End (UTC):</label>
+      <label for="end">End (UTC)</label><br/>
       <input type="date" id="end-date" name="period-end-date" {% if form_data is defined %}value="{{form_data['period-end-date']}}"{% endif %}required>
       <input type="time" id="end-time" name="period-end-time" {% if form_data is defined %}value="{{form_data['period-end-time']}}"{% else %} value="00:00"{% endif %} required>
     </div>

--- a/sfa_dash/templates/sidebar.html
+++ b/sfa_dash/templates/sidebar.html
@@ -1,4 +1,4 @@
-<div class="col-sm-3 col-xs-12 sidebar-wrapper mt-3 border-right">
+<div class="col-md-3 col-sm-12 sidebar-wrapper mt-3">
   <ul class="sidebar-menu menu-list">
     <li class="py-1"><a href="{{ url_for('data_dashboard.sites') }}">Sites</a></li>
     <li class="py-1"><a href="{{ url_for('data_dashboard.observations') }}">Observations</a></li>


### PR DESCRIPTION
Should create more sane layouts on smaller screens.

- Stops date/time fields on download pages from overflowing out of the viewport by explicitly setting the width of form-group to 100%
- Stacks the sidebar on top of the rest of the content on small screens (767px wide and smaller).
- Also introduces an 'x' box in the organization filter, to close the dropdown.  