### PR TITLE
add jinja filter for formatting raw json timestamps closes #94

### DIFF
--- a/sfa_dash/filters.py
+++ b/sfa_dash/filters.py
@@ -1,3 +1,6 @@
+import pandas as pd
+
+
 from solarforecastarbiter.datamodel import ALLOWED_VARIABLES, COMMON_NAMES
 
 
@@ -22,6 +25,12 @@ def api_varname_to_units(api_varname):
 
 def human_friendly_datatype(data_type):
     return data_type_mapping[data_type]
+
+
+def format_datetime(dt_string):
+    """Temporary solution to formatting datetime strings returned by API
+    """
+    return pd.Timestamp(dt_string).strftime('%Y-%m-%d %H:%M:%SZ')
 
 
 def display_timedelta(minutes):
@@ -67,3 +76,4 @@ def register_jinja_filters(app):
     app.jinja_env.filters['var_to_units'] = api_varname_to_units
     app.jinja_env.filters['display_timedelta'] = display_timedelta
     app.jinja_env.filters['convert_data_type'] = human_friendly_datatype
+    app.jinja_env.filters['format_datetime'] = format_datetime

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -12,7 +12,7 @@
             <li><b>Organization:</b> {{ permission['organization'] }} </li>
         </ul>
         <ul class="data-metadata-fields col-md-6 col-xs-12">
-            <li><b>Created:</b> {{ permission['created_at'] }}</li>
+            <li><b>Created:</b> {{ permission['created_at'] | format_datetime }}</li>
         </ul>
     </div>
 </div>
@@ -37,7 +37,7 @@
         {% else %}
         <td><a href="{{ url_for('data_dashboard.'+dashboard_type+'_view', uuid=uuid) }}">{{ obj['name'] }}</a></td>
         {% endif %}
-        <td>{{ obj['added_to_permission'] }} </td>
+        <td>{{ obj['added_to_permission'] | format_datetime}} </td>
       </tr>
 
     {% endfor %}

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -11,8 +11,8 @@
             <li><b>Organization:</b> {{ role['organization'] }} </li>
         </ul>
         <ul class="data-metadata-fields col-md-6 col-xs-12">
-            <li><b>Created:</b> {{ role['created_at'] }}</li>
-            <li><b>Last Modified:</b> {{ role['modified_at'] }}</li>
+            <li><b>Created:</b> {{ role['created_at'] | format_datetime}}</li>
+            <li><b>Last Modified:</b> {{ role['modified_at'] |format_datetime }}</li>
         </ul>
     </div>
 </div>
@@ -33,7 +33,7 @@
     {% for perm_id, perm in role['permissions'].items() %}
       <tr>
           <td><a href="{{ url_for('admin.permission_view', uuid=perm_id) }}">{{ perm['description'] }}</a></td>
-          <td>{{ perm['added_to_role'] }}</td>
+          <td>{{ perm['added_to_role'] | format_datetime}}</td>
       </tr>
     {% endfor %}
   </tbody>

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -11,8 +11,8 @@
             <li ><b>Organization:</b> {{ user['organization'] }} </li>
         </ul>
         <ul class="data-metadata-fields col-md-6 col-xs-12">
-            <li><b>Created:</b> {{user['created_at']}}</li>
-            <li><b>Last Modified:</b> {{user['modified_at']}}</li>
+            <li><b>Created:</b> {{user['created_at'] | format_datetime }}</li>
+            <li><b>Last Modified:</b> {{user['modified_at'] | format_datetime }}</li>
         </ul>
     </div>
 </div>
@@ -37,7 +37,7 @@
       <tr>
           <td><a href="{{ url_for('admin.role_view', uuid=role_id) }}">{{ role['name'] }}</a></td>
           <td>{{ role['organization'] }}</td>
-          <td>{{ role['added_to_user'] }}</td>
+          <td>{{ role['added_to_user'] | format_datetime }}</td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
Adds a `format_datetime` filter to the jinja environment for parsing dates and converting them to '%Y-%m-%d %H:%M:%SZ' format.