### PR TITLE
handle files with incorrect mimetype closes #100

### DIFF
--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -296,7 +296,10 @@ class UploadForm(BaseView):
         posted_file = request.files[f'{self.data_type}-data']
         if posted_file.filename == '':
             return 'no filename'
-        if posted_file.mimetype == 'text/csv':
+        if (
+                posted_file.mimetype == 'text/csv' or
+                posted_file.mimetype == 'application/vnd.ms-excel'
+        ):
             posted_data = posted_file.read()
             post_request = self.api_handle.post_values(
                 uuid,

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -305,6 +305,11 @@ class UploadForm(BaseView):
         elif posted_file.mimetype == 'application/json':
             posted_data = json.load(posted_file)
             post_request = self.api_handle.post_values(uuid, posted_data)
+        else:
+            errors = {
+                'mime-type': [f'Unsupported file type {posted_file.mimetype}.']
+            }
+            return render_template(self.template, uuid=uuid, errors=errors)
         if post_request.status_code != 201:
             errors = post_request.json()['errors']
             return render_template(self.template, uuid=uuid, errors=errors)


### PR DESCRIPTION
Reloads the upload form with an error about unsupported file type when a user tries to upload anythong other than text/csv or application/json. This may need to be investigated further as it looks like the original error was from trying to upload a .csv file with a different mimetype. Perhaps this was due to being created with excel and we should support that?