### PR TITLE
Reports widget update

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -58,8 +58,8 @@ class ReportForm(BaseView):
         (forecast-n, observation-n) input elements inserted by
         report-handling.js
         """
-        fx = self.field_values('forecast-', form_data)
-        obs = self.field_values('observation-', form_data)
+        fx = self.field_values('forecast-id-', form_data)
+        obs = self.field_values('observation-id-', form_data)
         pairs = list(zip(fx, obs))
         return pairs
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -41,7 +41,6 @@ class ReportForm(BaseView):
 
     def template_args(self):
         return {
-            "form_title": "Create new Report",
             "page_data": self.get_pairable_objects(),
         }
 

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -182,7 +182,6 @@ ul.object-pair-list{
   padding-left: 0;
 }
 a.object-pair-delete-button{
-    position: absolute;
     top: 50%;
     color: #A00 !important;
 }
@@ -356,4 +355,27 @@ a.help-button{
 
 [role="button"]{
     cursor: pointer;
+}
+.empty-reports-list{
+    list-style: none;
+}
+a:not([href]).object-pair-button{
+    color: #007bff;
+}
+a:not([href]).object-pair-button:hover{
+    color: #0056b3;
+}
+.object-pair-button::after{
+    width: 0; 
+    height: 0; 
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-bottom: 5px solid #007bff;
+    content: "";
+    position: absolute;
+    margin-top: 7px;
+    margin-left: 7px;
+}
+.object-pair-button.collapsed::after{
+    transform: rotate(180deg);
 }

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -3,116 +3,162 @@
  */
 $(document).ready(function() {
     function registerDatetimeValidator(input_name){
-          $(`[name="${input_name}"]`).keyup(function (){
-              if($(`[name="${input_name}"]`).val().match(
-                    /(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\Z/
-              )) {
-                    $(`[name="${input_name}"]`)[0].setCustomValidity("");
-              } else {
-                    $(`[name="${input_name}"]`)[0].setCustomValidity('Please enter a datetime in the format "YYYY-MM-DDTHH:MMZ');
-              }
-          });
+        $(`[name="${input_name}"]`).keyup(function (){
+            if($(`[name="${input_name}"]`).val().match(
+                  /(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\Z/
+            )) {
+                  $(`[name="${input_name}"]`)[0].setCustomValidity("");
+            } else {
+                  $(`[name="${input_name}"]`)[0].setCustomValidity('Please enter a datetime in the format "YYYY-MM-DDTHH:MMZ');
+            }
+        });
     }
     if ($('.object-pair-list')[0]){
-        function insertSelectOptions(index){
-            /*
-             * Generates select options for a observation, forecast pair
-             */
-            var observation_selector = `[name="observation-${index}"]`;
-            var forecast_selector = `[name="forecast-${index}"]`;
+        function addPair(obsName, obsId, fxName, fxId){
+            var new_object_pair = $(`<div class="object-pair object-pair-${pair_index}">
+                      <div class="form-element">
+                        <div class="input-wrapper">
+                          <input type="text" class="form-control observation-field" name="observation-name-${pair_index}"  required disabled value="${obsName}"/>
+                          <input type="hidden" class="form-control observation-field" name="observation-id-${pair_index}" required value="${obsId}"/>
+                        </div>
+                      </div>
+                      <div class="form-element">
+                        <div class="input-wrapper">
+                          <input type="text" class="form-control forecast-field" name="forecast-name-${pair_index}" required disabled value="${fxName}"/>
+                          <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
+                        </div>
+                      </div>
+                    <a role="button" class="object-pair-delete-button">x</a>
+                   </div>`);
+            var remove_button = new_object_pair.find(".object-pair-delete-button");
+            remove_button.click(function(){
+                new_object_pair.remove();
+                if ($('.object-pair-list .object-pair').length == 0){
+                   $('.empty-reports-list')[0].hidden = false;
+                }
+            });
+            return new_object_pair;
+        }
+        
+
+        function createPairSelector(){
+          /* 
+           * Generate the two select widgets and button for adding new object pairs  
+           */
+
+          var widgetContainer = $('<div class="pair-selector-wrapper show"></div>');
+          var obsSelector = $(`<div class="form-element">
+                        <label>Select an Observation</label><br>
+                        <div class="input-wrapper">
+                          <select id="observation-select" class="form-control observation-field" name="observation-select" size="15">
+                          </select>
+                        </div>
+                      </div>`);
+          var fxSelector = $(`<div class="form-element">
+                        <label>Select a Forecast</label><br>
+                        <div class="input-wrapper">
+                          <select id="forecast-select" class="form-control forecast-field" name="forecast-select" size="15">
+                            <option name="no-forecasts" disabled hidden>No matching Forecasts</option>
+                          </select>
+                        </div>
+                     </div>`);
+            var addButton = $('<a role="button" class="btn btn-primary" id="add-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
+            widgetContainer.append(obsSelector);
+            widgetContainer.append(fxSelector);
+            widgetContainer.append(addButton);
+
+            // add options to the select elements from page_data
+            var observation_select = obsSelector.find('#observation-select');
+            var forecast_select = fxSelector.find('#forecast-select');
             $.each(page_data['observations'], function(){
-                $(observation_selector).append(
+                observation_select.append(
                     $('<option></option>')
                         .html(this.name)
                         .val(this.observation_id)
                         .attr('data-site-id', this.site_id));
             });
             $.each(page_data['forecasts'], function(){
-                $(forecast_selector).append(
+                forecast_select.append(
                     $('<option></option>')
                         .html(this.name)
                         .val(this.forecast_id)
                         .attr('data-site-id', this.site_id));
             });
-            $(observation_selector).change(function (){
+            observation_select.change(function (){
                 /*
                  * React to a change in observation to hide any non-applicable forecasts from the
                  * select list and remove the current selection if it is invalid.
                  */
-                observation_site = $(observation_selector + ' option:selected').attr('data-site-id')
+                observation_site = observation_select.find('option:selected').attr('data-site-id')
                 if (observation_site){
-                    forecasts = $(forecast_selector + ' option').slice(1);
+                    forecasts = forecast_select.find('option');
                     forecasts.removeAttr('hidden');
                     forecasts.each(function (fx){
                         if (this.dataset.siteId != observation_site){
                             this.hidden = true;
-                            // If the current selected forecast is invalid, reset the selection
-                            if (this.dataset.siteId != $(forecast_selector).val()){
-                                $(forecast_selector).val('select a forecast');
-                            }
+                            
+                        } else if (this.hidden){
+                            this.hidden = false;
                         }
                     });
+                    // if the currently selected forecast is hidden, deselect it.
+                    if (forecast_select.find(':selected')[0] && forecast_select.find(':selected')[0].hidden ) {
+                        forecast_select.val('');
+                    }
+                    // Hide/show the "no matching forecasts options
+                    if (forecast_select.find('option').not(":hidden").length == 0){
+                        $('[name="no-forecasts"]')[0].hidden = false;
+                    } else {
+                        $('[name="no-forecasts"]')[0].hidden = true;
+                    }
                 }
             });
-        }
-  
-        function newPair(){
-          /* 
-           *  Generate the base HTML for a new pair of observation, forecast select options.
-           *  The options should be initialized by calling insertSelectOptions with the
-           *  current pair index
-           */
-          var new_object_pair = $(`<li class="object-pair object-pair-${pair_index}">
-                      <div class="form-element">
-                        <label>Observation</label><br>
-                        <div class="input-wrapper">
-                          <select class="form-control observation-field" name="observation-${pair_index}" required>
-                          <option disabled value selected>select an observation</option>
-                          </select>
-                        </div>
-                        <a data-toggle="collapse" data-target=".observation-${pair_index}-help-text" role="button" href="" class="help-button">?</a>
-                        <span class="observation-${pair_index}-help-text form-text text-muted help-text collapse" aria-hidden="">Observation to compare Forecast against.</span>
-                      </div>
-                      <div class="form-element">
-                        <label>Forecast</label><br>
-                        <div class="input-wrapper">
-                          <select class="form-control forecast-field" name="forecast-${pair_index}" required>
-                          <option disabled value selected>select a forecast</option>
-                          </select>
-                        </div>
-                        <a data-toggle="collapse" data-target=".forecast-${pair_index}-help-text" role="button" href="" class="help-button">?</a>
-                        <span class="forecast-${pair_index}-help-text form-text text-muted help-text collapse" aria-hidden="">Forecast to compare.</span>
-                      </div>
-                   <a role="button" class="object-pair-delete-button">x</a>
-                   </li>`);
-            var remove_button = new_object_pair.find(".object-pair-delete-button");
-            remove_button.click(function(){new_object_pair.remove();});
-            return new_object_pair;
+            addButton.click(function(){
+                /*
+                 * 'Add a Forecast, Observation pair button on button click
+                 *
+                 * On click, appends a new pair of inputs inside the 'pair_container' div, initializes
+                 * their select options and increment the pair_index.
+                 */
+                // check if both inputs have a selection
+                if (observation_select.val() && forecast_select.val()){
+                    var selected_observation = observation_select.find('option:selected')[0];
+                    var selected_forecast = forecast_select.find('option:selected')[0];
+                    pair = addPair(selected_observation.text,
+                                   selected_observation.value,
+                                   selected_forecast.text,
+                                   selected_forecast.value);
+                    
+                    pair_container.append(pair);
+                    pair_index++;
+                    observation_select.val('');
+                    forecast_select.val('');
+                    $(".empty-reports-list")[0].hidden = true;
+                } else {
+                    // TODO: prompt to make a selection
+                }
+            });
+            return widgetContainer;
         }
         
   
         /*
-         * Initialize pair_index, and a global handle to the object_pair container
+         * Initialize global variables
+         * pair_index - used for labelling matching pairs of observations/forecasts
+         * pair_container - JQuery handle for the ul to hold pair elements
+         * pair_control_container - JQuery handle for div to hold the select widgets
+         *     used to create new pairs
          */
         pair_container = $('.object-pair-list');
+        pair_control_container = $('.object-pair-control')
         pair_index = 0;
         
-        // Initialize the first object_pair
-        pair_container.append(newPair());
-        insertSelectOptions(pair_index);
-        pair_index++;
-  
-        $('#add-object-pair').click(function(){
-            /*
-             * 'Add a Forecast, Observation pair button callback
-             *
-             * On click, appends a new pair of inputs inside the 'pair_container' div, initializes
-             * their select options and increment the pair_index.
-             */
-            pair_container.append(newPair());
-            insertSelectOptions(pair_index);
-            pair_index++;
-        });
+        // 
+        pair_selector = createPairSelector();
+        console.log(pair_selector);
+        pair_control_container.append($('<a role="button" class="full-width object-pair-button" data-toggle="collapse" data-target=".pair-selector-wrapper">Add Observation Forecast pairs</a>'));
+        pair_control_container.append(pair_selector);
+        
     }
     registerDatetimeValidator('period-start');
     registerDatetimeValidator('period-end')

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -40,12 +40,10 @@ $(document).ready(function() {
             return new_object_pair;
         }
         
-
         function createPairSelector(){
           /* 
            * Generate the two select widgets and button for adding new object pairs  
            */
-
           var widgetContainer = $('<div class="pair-selector-wrapper show"></div>');
           var obsSelector = $(`<div class="form-element">
                         <label>Select an Observation</label><br>
@@ -75,28 +73,31 @@ $(document).ready(function() {
                     $('<option></option>')
                         .html(this.name)
                         .val(this.observation_id)
-                        .attr('data-site-id', this.site_id));
+                        .attr('data-site-id', this.site_id)
+                        .attr('data-variable', this.variable));
             });
             $.each(page_data['forecasts'], function(){
                 forecast_select.append(
                     $('<option></option>')
                         .html(this.name)
                         .val(this.forecast_id)
-                        .attr('data-site-id', this.site_id));
+                        .attr('data-site-id', this.site_id)
+                        .attr('data-variable', this.variable));
             });
             observation_select.change(function (){
                 /*
                  * React to a change in observation to hide any non-applicable forecasts from the
                  * select list and remove the current selection if it is invalid.
                  */
-                observation_site = observation_select.find('option:selected').attr('data-site-id')
+                observation = observation_select.find('option:selected');
+                observation_site = observation.attr('data-site-id');
+                observation_variable = observation.attr('data-variable');
                 if (observation_site){
                     forecasts = forecast_select.find('option');
                     forecasts.removeAttr('hidden');
                     forecasts.each(function (fx){
-                        if (this.dataset.siteId != observation_site){
+                        if (this.dataset.siteId != observation_site || this.dataset.variable != observation_variable){
                             this.hidden = true;
-                            
                         } else if (this.hidden){
                             this.hidden = false;
                         }
@@ -134,13 +135,19 @@ $(document).ready(function() {
                     observation_select.val('');
                     forecast_select.val('');
                     $(".empty-reports-list")[0].hidden = true;
+                    forecast_select.css('border', '');
+                    observation_select.css('border', '');
                 } else {
-                    // TODO: prompt to make a selection
+                    if (forecast_select.val() == null){
+                        forecast_select.css('border', '2px solid #F99');
+                    }
+                    if (observation_select.val() == null){
+                        observation_select.css('border', '2px solid #F99');
+                    }
                 }
             });
             return widgetContainer;
         }
-        
   
         /*
          * Initialize global variables
@@ -153,9 +160,7 @@ $(document).ready(function() {
         pair_control_container = $('.object-pair-control')
         pair_index = 0;
         
-        // 
         pair_selector = createPairSelector();
-        console.log(pair_selector);
         pair_control_container.append($('<a role="button" class="full-width object-pair-button" data-toggle="collapse" data-target=".pair-selector-wrapper">Add Observation Forecast pairs</a>'));
         pair_control_container.append(pair_selector);
         

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -56,7 +56,7 @@ $(document).ready(function() {
                         <label>Select a Forecast</label><br>
                         <div class="input-wrapper">
                           <select id="forecast-select" class="form-control forecast-field" name="forecast-select" size="15">
-                            <option name="no-forecasts" disabled hidden>No matching Forecasts</option>
+                            <option name="no-forecasts" disabled>No matching Forecasts</option>
                           </select>
                         </div>
                      </div>`);
@@ -81,6 +81,7 @@ $(document).ready(function() {
                     $('<option></option>')
                         .html(this.name)
                         .val(this.forecast_id)
+                        .attr('hidden', true)
                         .attr('data-site-id', this.site_id)
                         .attr('data-variable', this.variable));
             });
@@ -132,8 +133,6 @@ $(document).ready(function() {
                     
                     pair_container.append(pair);
                     pair_index++;
-                    observation_select.val('');
-                    forecast_select.val('');
                     $(".empty-reports-list")[0].hidden = true;
                     forecast_select.css('border', '');
                     observation_select.css('border', '');

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -1,6 +1,7 @@
 {% import "forms/form_macros.jinja" as form %}
 {% extends "dash/data.html" %}
 {% block content %}
+<script src="/static/js/report-handling.js"></script>
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
 {% if form_title %}<h3>{{ form_title }}</h3> {% endif %}

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -4,7 +4,7 @@
 <script src="/static/js/report-handling.js"></script>
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
-{% if form_title %}<h3>{{ form_title }}</h3> {% endif %}
+<h3>Create New Report</h3>
 <form action="{{ url_for('forms.create_report') }}" method="post" id="report-form">
   <div class="form-group">
       {% if form_data is not defined %} {% set form_data = {} %}{% endif %}

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -32,10 +32,15 @@
      </div>
      {# The following empty list is a target for the javascript found in report-handling.js
         list items are added dynamically on page load #}
+
+     <h5>Observation, Forecast pairs</h5>
 	 <div class="form-element full-width border" style="border-radius:10px;margin:.5em 1em;">
-       <ul class="object-pair-list">
-       </ul>
-       <a href="#" class="btn btn-primary" id="add-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>
+       <div class="form-element">Observations</div><div class="form-element">Forecasts</div>
+       <div class="object-pair-list">
+         <div class="empty-reports-list alert alert-warning">No Pairs Selected</div>
+       </div>
+       <div class="object-pair-control">
+       </div>
 	 </div>
     {#
      <div class="form-element">

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -34,9 +34,9 @@
 
 <script src="/static/js/table-search.js"></script>
 <script src="/static/js/table-checkall.js"></script>
-<script src="/static/js/report-handling.js"></script>
 
 
+{# inject the page_data json variable if provided by jinja #}
 {% if page_data is defined %}
 <script>
     var page_data = JSON.parse('{{ page_data | tojson }}');


### PR DESCRIPTION
Makes the Report observation and forecast pair widget less frustrating to use. Has a persistent list of observations. When an observation selection is made, the forecasts list is limited by site and variable. 