### PR TITLE
excel file handling

### DIFF
--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -303,11 +303,12 @@ class UploadForm(BaseView):
             posted_data = posted_file.read()
             try:
                 decoded_data = posted_data.decode('utf-8')
-            except UnicodeDecodeError as e:
+            except UnicodeDecodeError:
                 errors = {
-                    'file-type': ['Failed to decode file. Please ensure file is a CSV '
-                                  'with UTF-8 encoding. This error can sometimes occur '
-                                  'when a csv is improperly exported from excel.'],
+                    'file-type': [
+                        'Failed to decode file. Please ensure file is a CSV '
+                        'with UTF-8 encoding. This error can sometimes occur '
+                        'when a csv is improperly exported from excel.'],
                 }
                 return render_template(self.template, uuid=uuid, errors=errors)
             else:

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -301,10 +301,20 @@ class UploadForm(BaseView):
                 posted_file.mimetype == 'application/vnd.ms-excel'
         ):
             posted_data = posted_file.read()
-            post_request = self.api_handle.post_values(
-                uuid,
-                posted_data.decode('utf-8'),
-                json=False)
+            try:
+                decoded_data = posted_data.decode('utf-8')
+            except UnicodeDecodeError as e:
+                errors = {
+                    'file-type': ['Failed to decode file. Please ensure file is a CSV '
+                                  'with UTF-8 encoding. This error can sometimes occur '
+                                  'when a csv is improperly exported from excel.'],
+                }
+                return render_template(self.template, uuid=uuid, errors=errors)
+            else:
+                post_request = self.api_handle.post_values(
+                    uuid,
+                    decoded_data,
+                    json=False)
         elif posted_file.mimetype == 'application/json':
             posted_data = json.load(posted_file)
             post_request = self.api_handle.post_values(uuid, posted_data)


### PR DESCRIPTION
catches errors that occur when an incorrectly encoded Excel csv or an actual excel file is uploaded. This duplicates the work done by the API, but the issue is raised when attempting to decode the file to utf-8, so it would fail here if we attempted to post to the API.