### PR TITLE
Reports pair selection updates

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -4,7 +4,7 @@ from flask import request, redirect, url_for, abort, render_template
 from requests.exceptions import HTTPError
 
 from solarforecastarbiter.reports.main import report_to_html_body
-from sfa_dash.api_interface import observations, forecasts, reports
+from sfa_dash.api_interface import observations, forecasts, sites, reports
 from sfa_dash.blueprints.base import BaseView
 
 
@@ -28,15 +28,20 @@ class ReportForm(BaseView):
         """
         observation_request = observations.list_metadata()
         forecast_request = forecasts.list_metadata()
+        site_request = sites.list_metadata()
         observation_list = observation_request.json()
         for obs in observation_list:
             del obs['extra_parameters']
         forecast_list = forecast_request.json()
         for fx in forecast_list:
             del fx['extra_parameters']
+        site_list = site_request.json()
+        for site in site_list:
+            del site['extra_parameters']
         return {
             'observations': observation_list,
             'forecasts': forecast_list,
+            'sites': site_list
         }
 
     def template_args(self):

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -280,6 +280,11 @@ a.help-button{
 .form-control{
   display: inline-block;
 }
+.form-control.half-width{
+  margin-left: 1em;
+  min-width: 250px;
+  width: 46%;
+}
 .input-wrapper{
   width: calc(100% - 29px);
   display: inline-flex;
@@ -378,4 +383,7 @@ a:not([href]).object-pair-button:hover{
 }
 .object-pair-button.collapsed::after{
     transform: rotate(180deg);
+}
+.report-field-filters{
+    display: inline-block;
 }

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -134,7 +134,7 @@ $(document).ready(function() {
              * Filter the Site Options Via the text found in the #site-option-search input
              */
             sites = siteSelector.find('option').slice(1);
-            sites.attr('hidden', false);
+            sites.removeAttr('hidden');
 
             toHide = searchSelect('#site-option-search', '#site-select', 1);
             if (toHide.length == sites.length){
@@ -152,7 +152,7 @@ $(document).ready(function() {
              * site and variable.
              */
             forecasts = $('#forecast-select option').slice(2);
-            forecasts.attr('hidden', false);
+            forecasts.removeAttr('hidden');
 
             selectedSite = $('#site-select :selected');
             site_id = selectedSite.attr('data-site-id');
@@ -175,7 +175,7 @@ $(document).ready(function() {
             // if all options are hidden, show "no matching forecasts"
             if (toHide.length == forecasts.length){
                 forecast_select.val('');
-                $('#no-forecasts').attr('hidden', false);
+                $('#no-forecasts').removeAttr('hidden');
             } else {
                 $('#no-forecasts').attr('hidden', true);
             }
@@ -206,7 +206,7 @@ $(document).ready(function() {
                     observation_select.val('');
                 }
                 if (toHide.length == observations.length){
-                    $('#no-observations').attr('hidden', false);
+                    $('#no-observations').removeAttr('hidden');
                 } else {
                     $('#no-observations').attr('hidden', true);
                 }

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -157,7 +157,7 @@ $(document).ready(function() {
             selectedSite = $('#site-select :selected');
             site_id = selectedSite.attr('data-site-id');
             $('#no-site-selection').attr('hidden', true);
-            variable_select = $('#variable-select :selected');
+            variable_select = $('#variable-select');
             variable = variable_select.val();
 
             // create a set of elements to hide from selected site, variable and search

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -16,19 +16,17 @@ $(document).ready(function() {
     if ($('.object-pair-list')[0]){
         function addPair(obsName, obsId, fxName, fxId){
             var new_object_pair = $(`<div class="object-pair object-pair-${pair_index}">
+                    <div class="input-wrapper">
                       <div class="form-element">
-                        <div class="input-wrapper">
                           <input type="text" class="form-control observation-field" name="observation-name-${pair_index}"  required disabled value="${obsName}"/>
                           <input type="hidden" class="form-control observation-field" name="observation-id-${pair_index}" required value="${obsId}"/>
-                        </div>
                       </div>
                       <div class="form-element">
-                        <div class="input-wrapper">
-                          <input type="text" class="form-control forecast-field" name="forecast-name-${pair_index}" required disabled value="${fxName}"/>
-                          <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
-                        </div>
+                        <input type="text" class="form-control forecast-field" name="forecast-name-${pair_index}" required disabled value="${fxName}"/>
+                        <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
                       </div>
-                    <a role="button" class="object-pair-delete-button">x</a>
+                     </div>
+                     <a role="button" class="object-pair-delete-button">x</a>
                    </div>`);
             var remove_button = new_object_pair.find(".object-pair-delete-button");
             remove_button.click(function(){

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -3,6 +3,10 @@
  */
 $(document).ready(function() {
     function registerDatetimeValidator(input_name){
+        /*
+         * Applies a regex validator to ensure ISO8601 compliance. This is however, very strict. We
+         * will need a better solution.
+         */
         $(`[name="${input_name}"]`).keyup(function (){
             if($(`[name="${input_name}"]`).val().match(
                   /(\d{4})-(\d{2})-(\d{2})T(\d{2})\:(\d{2})\Z/
@@ -13,210 +17,310 @@ $(document).ready(function() {
             }
         });
     }
-    if ($('.object-pair-list')[0]){
-        function addPair(obsName, obsId, fxName, fxId){
-            var new_object_pair = $(`<div class="object-pair object-pair-${pair_index}">
-                    <div class="input-wrapper">
-                      <div class="form-element">
-                          <input type="text" class="form-control observation-field" name="observation-name-${pair_index}"  required disabled value="${obsName}"/>
-                          <input type="hidden" class="form-control observation-field" name="observation-id-${pair_index}" required value="${obsId}"/>
-                      </div>
-                      <div class="form-element">
-                        <input type="text" class="form-control forecast-field" name="forecast-name-${pair_index}" required disabled value="${fxName}"/>
-                        <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
-                      </div>
-                     </div>
-                     <a role="button" class="object-pair-delete-button">x</a>
-                   </div>`);
-            var remove_button = new_object_pair.find(".object-pair-delete-button");
-            remove_button.click(function(){
-                new_object_pair.remove();
-                if ($('.object-pair-list .object-pair').length == 0){
-                   $('.empty-reports-list')[0].hidden = false;
-                }
-            });
-            return new_object_pair;
+
+
+    function createVariableSelect(){
+        /*
+         * Returns a JQuery object containing a select list of variable options.
+         */
+        var_names = {
+            'air_temperature': 'Air Temperature',
+            'wind_speed': 'Wind Speed',
+            'ghi': 'GHI',
+            'dni': 'DNI',
+            'dhi': 'DHI',
+            'poa_global': 'Plane of Array Irradiance',
+            'relative_humidity': 'Relative Humidty',
+            'ac_power': 'AC Power',
+            'dc_power': 'DC Power',
+            'availability': 'Availability',
+            'curtailment': 'Curtailment'
         }
+        variables = new Set();
+        for (fx in page_data['forecasts']){
+            variables.add(page_data['forecasts'][fx].variable);
+        }
+        variable_select = $('<select id="variable-select" class="form-control half-width"><option selected value>All Variables</option></select>');
+        variables.forEach(function(variable){
+            variable_select.append(
+                $('<option></option>')
+                    .html(var_names[variable])
+                    .val(variable));
+        });
+        return variable_select
+    }
+
+
+    function searchSelect(inputSelector, selectSelector, offset=0){
+        /*
+         * Retrieves the value the <input> element identified by inputSelector and
+         * returns a jquery list of the <option> elements inside the element
+         * identified by selectSelector that do not contain the value.
+         * Passing an offset ignores the first offset items.
+         */
+        var searchTerm = $(inputSelector).val();
+        var searchSplit = searchTerm.replace(/ /g, "'):containsi('");
+        return $(selectSelector + " option").slice(offset).not(":containsi('" + searchSplit + "')");
+    }
+
+
+    function addPair(obsName, obsId, fxName, fxId){
+        /*
+         * Returns a Jquery object containing 4 input elements representing a forecast,
+         * observation pair:
+         *  forecast-name-<index>
+         *  forecast-id-<index>
+         *  observation-name-<indeX>
+         *  observation-id-<indeX>
+         *  where index associates the pairs with eachother for easier parsing when the form
+         *  is submitted.
+         */
+        var new_object_pair = $(`<div class="object-pair object-pair-${pair_index}">
+                <div class="input-wrapper">
+                  <div class="col-md-6">
+                    <input type="text" class="form-control forecast-field" name="forecast-name-${pair_index}" required disabled value="${fxName}"/>
+                    <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
+                  </div>
+                  <div class="col-md-6">
+                    <input type="text" class="form-control observation-field" name="observation-name-${pair_index}"  required disabled value="${obsName}"/>
+                    <input type="hidden" class="form-control observation-field" name="observation-id-${pair_index}" required value="${obsId}"/>
+                  </div>
+                 </div>
+                 <a role="button" class="object-pair-delete-button">x</a>
+               </div>`);
+        var remove_button = new_object_pair.find(".object-pair-delete-button");
+        remove_button.click(function(){
+            new_object_pair.remove();
+            if ($('.object-pair-list .object-pair').length == 0){
+                $('.empty-reports-list')[0].hidden = false;
+            }
+        });
+        return new_object_pair;
+    }
+
+
+    function newSelector(field_type, depends_on=null){
+        /*
+         * Returns a JQuery object containing labels and select elements for appending options to.
+         * Initializes with one default and one optional select option:
+         *     Always adds an option containing "No matching <field_Type>s
+         *     If depends_on is provided, inserts a "Please select a <depends_on> option>
+         */
+        return $(`<div class="form-element full-width ${field_type}-select-wrapper">
+                    <label>Select a ${field_type}</label>
+                      <div class="report-field-filters"><input id="${field_type}-option-search" class="form-control half-width" placeholder="Search by ${field_type} name"/></div><br>
+                    <div class="input-wrapper">
+                      <select id="${field_type}-select" class="form-control ${field_type}-field" name="${field_type}-select" size="5">
+                      ${depends_on ? `<option id="no-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
+                      <option id="no-${field_type}s" disabled hidden>No matching ${field_type}s</option>
+                    </select>
+                    </div>
+                  </div>`);
+    }
+
+
+    function createPairSelector(){
+        /*
+         * Returns a JQuery object containing Forecast, Observation pair widgets to insert into the DOM
+         */
         
-        function createPairSelector(){
-          /* 
-           * Generate the two select widgets and button for adding new object pairs  
-           */
-          var widgetContainer = $('<div class="pair-selector-wrapper collapse"></div>');
-          var siteSelector = $(`<div class="form-element full-width site-select-wrapper">
-                        <label>Select a Site</label><br>
-                        <div class="input-wrapper">
-                          <select id="site-select" class="form-control site-field" name="site-select" size="5">
-                        </select>
-                        </div>
-                      </div>`);
+        /*
+         *  Filtering Functions
+         *      Callbacks for hidding/showing select list options based on the searchbars
+         *      for each field and previously made selections
+         */
+        function filterSites(){
+            /*
+             * Filter the Site Options Via the text found in the #site-option-search input
+             */
+            sites = siteSelector.find('option').slice(1);
+            sites.attr('hidden', false);
 
-          var obsSelector = $(`<div class="form-element full-width observation-select-wrapper collapse">
-                        <label>Select an Observation</label><br>
-                        <div class="input-wrapper">
-                          <select id="observation-select" class="form-control observation-field" name="observation-select" size="5">
-                            <option id="no-observations" disabled hidden>No matching Observations</option>
-                          </select>
-                        </div>
-                      </div>`);
-          var fxSelector = $(`<div class="form-element full-width forecast-select-wrapper collapse">
-                        <label>Select a Forecast</label><br>
-                        <div class="input-wrapper">
-                          <select id="forecast-select" class="form-control forecast-field" name="forecast-select" size="5">
-                            <option id="no-forecasts" disabled hidden>No matching Forecasts</option>
-                          </select>
-                        </div>
-                     </div>`);
-            var addButton = $('<a role="button" class="btn btn-primary" id="add-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
-            widgetContainer.append(siteSelector);
-            widgetContainer.append(fxSelector);
-            widgetContainer.append(obsSelector);
-            widgetContainer.append(addButton);
+            toHide = searchSelect('#site-option-search', '#site-select', 1);
+            if (toHide.length == sites.length){
+                $('#no-sites').removeAttr('hidden');
+            } else {
+                $('#no-sites').attr('hidden', true);
+            }
+            toHide.attr('hidden', true);
+        }
 
-            // add options to the select elements from page_data
-            var observation_select = obsSelector.find('#observation-select');
-            var forecast_select = fxSelector.find('#forecast-select');
-            var site_select = siteSelector.find('#site-select');
-            $.each(page_data['sites'], function(){
-                site_select.append(
-                    $('<option></option>')
-                        .html(this.name)
-                        .val(this.site_id)
-                        .attr('data-site-id', this.site_id));
-            });
-            $.each(page_data['observations'], function(){
-                observation_select.append(
-                    $('<option></option>')
-                        .html(this.name)
-                        .val(this.observation_id)
-                        .attr('hidden', true)
-                        .attr('data-site-id', this.site_id)
-                        .attr('data-variable', this.variable));
-            });
-            $.each(page_data['forecasts'], function(){
-                forecast_select.append(
-                    $('<option></option>')
-                        .html(this.name)
-                        .val(this.forecast_id)
-                        .attr('hidden', true)
-                        .attr('data-site-id', this.site_id)
-                        .attr('data-variable', this.variable));
-            });
-            site_select.change(function (){
-                site = site_select.find('option:selected');
-                site_id = site.attr('data-site-id');
-                if (site_id){
-                    forecasts = forecast_select.find('option').slice(1);
-                    forecasts.removeAttr('hidden');
-                    matching_forecasts = 0;
-                    forecasts.each(function (fx){
-                        if (this.dataset.siteId != site_id){
-                            this.hidden = true;
-                        } else {
-                            this.hidden = false;
-                            matching_forecasts++;
-                        }
-                    });
-                    // if the currently selected forecast is hidden, deselect it.
-                    if (forecast_select.find(':selected')[0] && forecast_select.find(':selected')[0].hidden ) {
-                        forecast_select.val('');
-                    }
 
-                    // Hide/show the "no matching forecasts options
-                    if (matching_forecasts == 0){
-                        $('#no-forecasts')[0].hidden = false;
-                    } else {
-                        $('#no-forecasts')[0].hidden = true;
-                    }
-                    forecast_select.change();
-                    $('.forecast-select-wrapper').collapse('show')
-                                    }
-            });
-            forecast_select.change(function (){
-                /*
-                 * React to a change in observation to hide any non-applicable forecasts from the
-                 * select list and remove the current selection if it is invalid.
-                 */
-                forecast = forecast_select.find('option:selected');
-                forecast_site = forecast.attr('data-site-id');
-                forecast_variable = forecast.attr('data-variable');
-                observations = observation_select.find('option').slice(1);
+        function filterForecasts(){
+            /*
+             * Hide options in the forecast selector based on the currently selected
+             * site and variable.
+             */
+            forecasts = $('#forecast-select option').slice(2);
+            forecasts.attr('hidden', false);
+
+            selectedSite = $('#site-select :selected');
+            site_id = selectedSite.attr('data-site-id');
+            $('#no-site-selection').attr('hidden', true);
+            variable_select = $('#variable-select :selected');
+            variable = variable_select.val();
+
+            // create a set of elements to hide from selected site, variable and search
+            var toHide = forecasts.not(`[data-site-id=${site_id}]`);
+            if (variable){
+                toHide = toHide.add(forecasts.not(`[data-variable=${variable}]`));
+            }
+            toHide = toHide.add(searchSelect('#forecast-option-search', '#forecast-select', 2));
+            toHide.attr('hidden', 'true');
+
+            // if current forecast selection is invalid, deselect
+            if (toHide.filter(':selected').length){
+                forecast_select.val('');
+            }
+            // if all options are hidden, show "no matching forecasts"
+            if (toHide.length == forecasts.length){
+                forecast_select.val('');
+                $('#no-forecasts').attr('hidden', false);
+            } else {
+                $('#no-forecasts').attr('hidden', true);
+            }
+            filterObservations();
+        }
+
+
+        function filterObservations(){
+            observations = $('#observation-select option').slice(2);
+            // get the attributes of the currently selected forecast
+            selectedForecast = $('#forecast-select :selected');
+            if (selectedForecast.length){
+                // Show all of the observations
                 observations.removeAttr('hidden');
-                matching_observations = 0;
-                observations.each(function (){
-                    if (this.dataset.siteId != forecast_site || this.dataset.variable != forecast_variable){
-                        this.hidden = true;
-                    } else{
-                        this.hidden = false;
-                        matching_observations++;
-                    }
-                });
-                // if the currently selected forecast is hidden, deselect it.
-                if (observation_select.find(':selected')[0] && observation_select.find(':selected')[0].hidden ) {
+                // retrieve the current site id and variable from the selected forecast
+                site_id = selectedForecast.attr('data-site-id');
+                variable = selectedForecast.attr('data-variable');
+                $('#no-forecast-selection').attr('hidden', true);
+
+                // Build the list of optiosn to hide by creating a set from
+                // the lists of elements to hide from search, site id and variable
+                var toHide = searchSelect('#observation-option-search', '#observation-select', 2);
+                toHide = toHide.add(observations.not(`[data-site-id=${site_id}]`));
+                toHide = toHide.add(observations.not(`[data-variable=${variable}]`));
+                toHide.attr('hidden', true);
+                // if the current selection is hidden, deselect it
+                if (toHide.filter(':selected').length){
                     observation_select.val('');
                 }
-                // Hide/show the "no matching observations options
-                var hidden_obs = observations.not(":hidden").length
-                if (matching_observations == 0){
-                    $('#no-observations')[0].hidden = false;
+                if (toHide.length == observations.length){
+                    $('#no-observations').attr('hidden', false);
                 } else {
-                    $('#no-observations')[0].hidden = true;
+                    $('#no-observations').attr('hidden', true);
                 }
-                if (forecast_select.val() == null){
-                    $('.observation-select-wrapper').collapse('hide');
-                } else {
-                    $('.observation-select-wrapper').collapse('show');
-                }
-            });
-            addButton.click(function(){
-                /*
-                 * 'Add a Forecast, Observation pair button on button click
-                 *
-                 * On click, appends a new pair of inputs inside the 'pair_container' div, initializes
-                 * their select options and increment the pair_index.
-                 */
-                // check if both inputs have a selection
-                if (observation_select.val() && forecast_select.val()){
-                    var selected_observation = observation_select.find('option:selected')[0];
-                    var selected_forecast = forecast_select.find('option:selected')[0];
-                    pair = addPair(selected_observation.text,
-                                   selected_observation.value,
-                                   selected_forecast.text,
-                                   selected_forecast.value);
-                    
-                    pair_container.append(pair);
-                    pair_index++;
-                    $(".empty-reports-list")[0].hidden = true;
-                    forecast_select.css('border', '');
-                    observation_select.css('border', '');
-                } else {
-                    if (forecast_select.val() == null){
-                        forecast_select.css('border', '2px solid #F99');
-                    }
-                    if (observation_select.val() == null){
-                        observation_select.css('border', '2px solid #F99');
-                    }
-                }
-            });
-            return widgetContainer;
+            } else {
+                observations.attr('hidden', true);
+                $('#no-forecast-selection').removeAttr('hidden');
+            }
         }
-  
-        /*
-         * Initialize global variables
-         * pair_index - used for labelling matching pairs of observations/forecasts
-         * pair_container - JQuery handle for the ul to hold pair elements
-         * pair_control_container - JQuery handle for div to hold the select widgets
-         *     used to create new pairs
-         */
-        pair_container = $('.object-pair-list');
-        pair_control_container = $('.object-pair-control')
-        pair_index = 0;
+
+        // Declare handles to each field's input widgets, and insert a variable select
+        // widget for Forecast filtering.
+        var widgetContainer = $('<div class="pair-selector-wrapper collapse"></div>');
+        var siteSelector = newSelector("site");
+        var obsSelector = newSelector("observation", "forecast");
+        var fxSelector = newSelector("forecast", "site");
+        var fxVariableSelector = createVariableSelect();
+        fxSelector.find('.report-field-filters').append(fxVariableSelector);
+        var addButton = $('<a role="button" class="btn btn-primary" id="add-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
+
+        // Add the elements to the widget Container, so that the single container may
+        // be inserted into the DOM
+        widgetContainer.append(siteSelector);
+        widgetContainer.append(fxSelector);
+        widgetContainer.append(obsSelector);
+        widgetContainer.append(addButton);
+
+        // Register callback functions
+        siteSelector.find('#site-option-search').keyup(filterSites);
+        obsSelector.find('#observation-option-search').keyup(filterObservations);
+        fxSelector.find('#forecast-option-search').keyup(filterForecasts);
+
+        // create variables pointing to the specific select elements
+        var observation_select = obsSelector.find('#observation-select');
+        var forecast_select = fxSelector.find('#forecast-select');
+        var site_select = siteSelector.find('#site-select');
         
-        pair_selector = createPairSelector();
-        pair_control_container.append($('<a role="button" class="full-width object-pair-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Observation pairs</a>'));
-        pair_control_container.append(pair_selector);
+        site_select.change(filterForecasts);
+        variable_select.change(filterForecasts);
+        forecast_select.change(filterObservations);
+
+        // insert options from page_data into the select elements
+        $.each(page_data['sites'], function(){
+            site_select.append(
+                $('<option></option>')
+                    .html(this.name)
+                    .val(this.site_id)
+                    .attr('data-site-id', this.site_id));
+        });
+        $.each(page_data['observations'], function(){
+            observation_select.append(
+                $('<option></option>')
+                    .html(this.name)
+                    .val(this.observation_id)
+                    .attr('hidden', true)
+                    .attr('data-site-id', this.site_id)
+                    .attr('data-variable', this.variable));
+        });
+        $.each(page_data['forecasts'], function(){
+            forecast_select.append(
+                $('<option></option>')
+                    .html(this.name)
+                    .val(this.forecast_id)
+                    .attr('hidden', true)
+                    .attr('data-site-id', this.site_id)
+                    .attr('data-variable', this.variable));
+        });
         
+        addButton.click(function(){
+            /*
+             * 'Add a Forecast, Observation pair button on button click
+             *
+             * On click, appends a new pair of inputs inside the 'pair_container' div, initializes
+             * their select options and increment the pair_index.
+             */
+            if (observation_select.val() && forecast_select.val()){
+                // If both inputs contain valid data, create a pair and add it to the DOM
+                var selected_observation = observation_select.find('option:selected')[0];
+                var selected_forecast = forecast_select.find('option:selected')[0];
+                pair = addPair(selected_observation.text,
+                               selected_observation.value,
+                               selected_forecast.text,
+                               selected_forecast.value);
+
+                pair_container.append(pair);
+                pair_index++;
+                $(".empty-reports-list")[0].hidden = true;
+                forecast_select.css('border', '');
+                observation_select.css('border', '');
+            } else {
+                // Otherwise apply a red border to alert the user to need of input
+                if (forecast_select.val() == null){
+                    forecast_select.css('border', '2px solid #F99');
+                }
+                if (observation_select.val() == null){
+                    observation_select.css('border', '2px solid #F99');
+                }
+            }
+        });
+        return widgetContainer;
     }
+    /*
+     * Initialize global variables
+     * pair_index - used for labelling matching pairs of observations/forecasts
+     * pair_container - JQuery handle for the ul to hold pair elements
+     * pair_control_container - JQuery handle for div to hold the select widgets
+     *     used to create new pairs
+     */
+    pair_container = $('.object-pair-list');
+    pair_control_container = $('.object-pair-control')
+    pair_index = 0;
+    // call the function to initialize the pair creation widget and insert it into the DOM
+    pair_selector = createPairSelector();
+    pair_control_container.append($('<a role="button" class="full-width object-pair-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Observation pairs</a>'));
+    pair_control_container.append(pair_selector);
     registerDatetimeValidator('period-start');
     registerDatetimeValidator('period-end')
 });

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -36,7 +36,7 @@
 
      <h5>Observation, Forecast pairs</h5>
 	 <div class="form-element full-width border" style="border-radius:10px;margin:.5em 1em;">
-       <div class="form-element">Observations</div><div class="form-element">Forecasts</div>
+       <div class="form-element">Forecasts</div><div class="form-element">Observations</div>
        <div class="object-pair-list">
          <div class="empty-reports-list alert alert-warning">No Pairs Selected</div>
        </div>


### PR DESCRIPTION
Updates the reports object/pair selection widgets:
![Screenshot from 2019-07-30 09-10-09](https://user-images.githubusercontent.com/21206164/62146269-e43e0e00-b2a9-11e9-933f-d8725be80ea6.png)

The new behavior is such that user must select a site, forecast and observation in that order. Each selection reduces the options for the next selection such that a user may only select a forecast and observation to analyze if they have the same Site and variable. 

Currently, any time a selected option is hidden when a filter is applied, the option will be deselected e.g. if a user selects a POA forecast and then applies a filter for GHI, the POA selection is deselected.