### PR TITLE
add start,end query params to fx/obs/cdf forecast pages

### DIFF
--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -336,7 +336,7 @@ class RoleDeletionView(AdminView):
         delete_request = roles.delete(uuid)
         if delete_request.status_code == 204:
             return redirect(url_for('admin.roles'))
-        elif delete_request.status_Code == 400:
+        elif delete_request.status_code == 400:
             response_json = delete_request.json()
             errors = response_json['errors']
             return self.get(uuid, errors=errors)
@@ -508,7 +508,7 @@ class PermissionDeletionView(AdminView):
         delete_request = permissions.delete(uuid)
         if delete_request.status_code == 204:
             return redirect(url_for('admin.permissions'))
-        elif delete_request.status_Code == 400:
+        elif delete_request.status_code == 400:
             response_json = delete_request.json()
             errors = response_json['errors']
             return self.get(uuid, errors=errors)

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -4,6 +4,7 @@ on site-section.
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.api_interface import sites
 from flask import render_template, request, url_for
+import pandas as pd
 
 
 class DataDashView(BaseView):
@@ -19,6 +20,29 @@ class DataDashView(BaseView):
     def get_site_metadata(self, site_id):
         site_request = sites.get_metadata(site_id)
         return site_request.json()
+
+    def parse_start_end_from_querystring(self):
+        """Attempts to find the start and end query parameters. If not found,
+        returns defaults spanning the last three days. Used for setting
+        reasonable defaults for requesting data for plots.
+
+        Returns
+        -------
+        start,end
+            Tuple of ISO 8601 datetime strings representing the start, end.
+        """
+        # set default arg to an invalid timestamp, to trigger ValueError
+        start_arg = request.args.get('start', 'x')
+        end_arg = request.args.get('end', 'x')
+        try:
+            start = pd.Timestamp(start_arg)
+        except ValueError:
+            start = pd.Timestamp.now() - pd.Timedelta('3days')
+        try:
+            end = pd.Timestamp(end_arg)
+        except ValueError:
+            end = pd.Timestamp.now()
+        return start.isoformat(), end.isoformat()
 
     def get(self, **kwargs):
         return render_template(self.template, **self.template_args(**kwargs))

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -37,11 +37,11 @@ class DataDashView(BaseView):
         try:
             start = pd.Timestamp(start_arg)
         except ValueError:
-            start = pd.Timestamp.now() - pd.Timedelta('3days')
+            start = pd.Timestamp.utcnow() - pd.Timedelta('3days')
         try:
             end = pd.Timestamp(end_arg)
         except ValueError:
-            end = pd.Timestamp.now()
+            end = pd.Timestamp.utcnow()
         return start.isoformat(), end.isoformat()
 
     def get(self, **kwargs):

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -44,7 +44,9 @@ class SingleObservationView(DataDashView):
         self.metadata['site'] = self.get_site_metadata(
             self.metadata['site_id'])
         temp_args = self.template_args(**kwargs)
-        values_request = observations.get_values(uuid)
+        start, end = self.parse_start_end_from_querystring()
+        values_request = observations.get_values(
+            uuid, params={'start': start, 'end': end})
         if values_request.status_code == 200:
             script_plot = timeseries_adapter(
                 'observation',
@@ -110,7 +112,9 @@ class SingleCDFForecastView(DataDashView):
         self.metadata['site'] = self.get_site_metadata(
             self.metadata['site_id'])
         temp_args = self.template_args(**kwargs)
-        values_request = cdf_forecasts.get_values(uuid)
+        start, end = self.parse_start_end_from_querystring()
+        values_request = cdf_forecasts.get_values(
+            uuid, params={'start': start, 'end': end})
         if values_request.status_code == 200:
             script_plot = timeseries_adapter(
                 'forecast',
@@ -169,7 +173,9 @@ class SingleForecastView(DataDashView):
         self.metadata['site'] = self.get_site_metadata(
             self.metadata['site_id'])
         temp_args = self.template_args(**kwargs)
-        values_request = forecasts.get_values(uuid)
+        start, end = self.parse_start_end_from_querystring()
+        values_request = forecasts.get_values(
+            uuid, params={'start': start, 'end': end})
         if values_request.status_code == 200:
             script_plot = timeseries_adapter(
                 'forecast',


### PR DESCRIPTION
closes #120 
adds start, end query params to the forecast pages and defaults to start=-3days, end=today.