### PR TITLE
Site perm 500

### DIFF
--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -537,6 +537,8 @@ class PermissionsCreation(AdminView):
             'applies_to_all': ('applies-to-all' in form_data),
             'object_type': self.data_type + 's',
         }
+        if self.data_type == 'cdf_forecast_group':
+            permission.update({'object_type': 'cdf_forecasts'})
         return permission
 
     def post(self):

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+
+
 from flask import url_for, render_template
 from flask.views import MethodView
 
@@ -32,14 +35,50 @@ class BaseView(MethodView):
         return formatted_subnav
 
     def breadcrumb_html(self, breadcrumb_dict):
-        """Build the breadcrumb navigation from keyword arguments.
+        """Build the breadcrumb navigation from an OrderedDict.
+
+        Parameters
+        ----------
+        breadcrumb_dict: OrderedDict
+            A dictionary of link_text: url. Urls can be relative
+            or absolute. See BaseView.get_breadcrumb_dict for an
+            example of the expected format.
+
+        Returns
+        -------
+        breadcrumb: str
+            HTML breadcrumb to be printed in the template. Note that
+            jinja requires the use of the 'safe' filter to avoid
+            escaping tags.
         """
         breadcrumb = ''
         for link_text, href in breadcrumb_dict.items():
             breadcrumb += f'/<a href="{href}">{link_text}</a>'
         return breadcrumb
 
-    def template_args():
+    def get_breadcrumb_dict(self):
+        """Creates an ordered dictionary used for building the page's
+        breadcrumb. Output can be passed to the BaseView.breadcrumb_html
+        function.
+
+        This is a base function that should be overridden by any view
+        that wants to display a breadcrumb.
+
+        Notes
+        -----
+        The breadcrumb dictionary should be built in the form:
+
+            { "link text": "url", ...}
+
+            Example:
+
+            { "home": "/", "users": "/users" }
+
+        Where the order of the keys is rendered from left to right.
+        """
+        return OrderedDict()
+
+    def template_args(self):
         return {}
 
     def get(self, **kwargs):

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -35,7 +35,7 @@ class BaseView(MethodView):
         """Build the breadcrumb navigation from keyword arguments.
         """
         breadcrumb = ''
-        for link_text, href in breadcrumb_dict:
+        for link_text, href in breadcrumb_dict.items():
             breadcrumb += f'/<a href="{href}">{link_text}</a>'
         return breadcrumb
 

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -13,13 +13,14 @@ class BaseView(MethodView):
         # so we must extract site data from the nested dict
         site_dict = metadata.get('site')
         if site_dict is None:
-            site_name = metadata.get('name')
+            site_name = metadata.get('site_id')
+            link_html = site_name
         else:
             site_name = site_dict['name']
-        site_id = metadata['site_id']
-        site_href = url_for('data_dashboard.site_view',
-                            uuid=site_id)
-        link_html = f'<a href="{site_href}">{site_name}</a>'
+            site_id = metadata['site_id']
+            site_href = url_for('data_dashboard.site_view',
+                                uuid=site_id)
+            link_html = f'<a href="{site_href}">{site_name}</a>'
         return link_html
 
     def format_subnav(self, **kwargs):

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -19,8 +19,7 @@ class DataDashView(BaseView):
         return temp_args
 
     def get_site_metadata(self, site_id):
-        site_request = sites.get_metadata(site_id)
-        return handle_response(site_request)
+        return handle_response(sites.get_metadata(site_id))
 
     def parse_start_end_from_querystring(self):
         """Attempts to find the start and end query parameters. If not found,

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -37,23 +37,23 @@ class SingleObservationView(DataDashView):
         return breadcrumb
 
     def get(self, uuid, **kwargs):
+        start, end = self.parse_start_end_from_querystring()
         try:
-            metadata_request = observations.get_metadata(uuid)
-            self.metadata = handle_response(metadata_request)
+            self.metadata = handle_response(
+                observations.get_metadata(uuid))
             self.metadata['site'] = self.get_site_metadata(
                 self.metadata['site_id'])
+            values = handle_response(observations.get_values(
+                uuid, params={'start': start, 'end': end}))
         except DataRequestException as e:
             temp_args = {'errors': e.errors}
         else:
             temp_args = self.template_args(**kwargs)
-            start, end = self.parse_start_end_from_querystring()
-            values_request = observations.get_values(
-                uuid, params={'start': start, 'end': end})
-            if values_request.status_code == 200:
+            if len(values) != 0:
                 script_plot = timeseries_adapter(
                     'observation',
                     self.metadata,
-                    values_request.json())
+                    values)
                 if script_plot is None:
                     temp_args.update(
                         {'messages':
@@ -109,23 +109,23 @@ class SingleCDFForecastView(DataDashView):
         return breadcrumb
 
     def get(self, uuid, **kwargs):
+        start, end = self.parse_start_end_from_querystring()
         try:
             self.metadata = handle_response(
                 cdf_forecasts.get_metadata(uuid))
             self.metadata['site'] = self.get_site_metadata(
                 self.metadata['site_id'])
+            values = handle_response(cdf_forecasts.get_values(
+                uuid, params={'start': start, 'end': end}))
         except DataRequestException as e:
             temp_args = {'errors': e.errors}
         else:
             temp_args = self.template_args(**kwargs)
-            start, end = self.parse_start_end_from_querystring()
-            values_request = cdf_forecasts.get_values(
-                uuid, params={'start': start, 'end': end})
-            if values_request.status_code == 200:
+            if len(values) != 0:
                 script_plot = timeseries_adapter(
                     'forecast',
                     self.metadata,
-                    values_request.json())
+                    values)
                 if script_plot is None:
                     temp_args.update(
                         {'messages':
@@ -173,23 +173,23 @@ class SingleForecastView(DataDashView):
         return breadcrumb
 
     def get(self, uuid, **kwargs):
+        start, end = self.parse_start_end_from_querystring()
         try:
             self.metadata = handle_response(
                 forecasts.get_metadata(uuid))
             self.metadata['site'] = self.get_site_metadata(
                 self.metadata['site_id'])
+            values = handle_response(forecasts.get_values(
+                uuid, params={'start': start, 'end': end}))
         except DataRequestException as e:
             temp_args = {'errors': e.errors}
         else:
             temp_args = self.template_args(**kwargs)
-            start, end = self.parse_start_end_from_querystring()
-            values_request = forecasts.get_values(
-                uuid, params={'start': start, 'end': end})
-            if values_request.status_code == 200:
+            if len(values) != 0:
                 script_plot = timeseries_adapter(
                     'forecast',
                     self.metadata,
-                    values_request.json())
+                    values)
                 if script_plot is None:
                     temp_args.update(
                         {'messages':

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -53,17 +53,7 @@ class SingleObjectView(DataDashView):
         self.human_label = human_friendly_datatype(self.data_type)
 
     def get_breadcrumb_dict(self):
-        """Creates an Ordered dictionary used for building the page's
-        breadcrumb. Output can be passed to the BaseView.breadcrumb_html
-        function.
-
-        Notes
-        -----
-        The breadcrumb dictionary should be built in the form:
-
-            { "link text": "url", ...}
-
-        Where the order of the keys is rendered from left to right.
+        """See BaseView.get_breadcrumb_dict.
         """
         breadcrumb_dict = OrderedDict()
         if self.data_type == 'cdf_forecast':
@@ -76,11 +66,11 @@ class SingleObjectView(DataDashView):
             breadcrumb_dict[self.metadata['site']['name']] = url_for(
                 'data_dashboard.site_view',
                 uuid=self.metadata['site_id'])
-            breadcrumb_dict[self.human_label + 's'] = url_for(
+            breadcrumb_dict[f'{self.human_label}s'] = url_for(
                 f'data_dashboard.{listing_view}',
                 uuid=self.metadata['site_id'])
         else:
-            breadcrumb_dict[self.human_label + 's'] = url_for(
+            breadcrumb_dict[f'{self.human_label}s'] = url_for(
                 f'data_dashboard.{listing_view}')
         # Insert a parent link for cdf_forecasts
         if self.data_type == 'cdf_forecast':
@@ -121,6 +111,9 @@ class SingleObjectView(DataDashView):
         """Generate a plot and bokeh script for the data between
         start and end. Note that the core library requires a 'site'
         key with the full site metadata to create a plot.
+
+        This inserts the rendered plot html and bokeh script into
+        the temp_args keys plot and bokeh_script respectively.
         """
         try:
             values = handle_response(self.api_handle.get_values(
@@ -184,17 +177,21 @@ class SingleCDFForecastGroupView(DataDashView):
     human_label = human_friendly_datatype('cdf_forecast')
 
     def get_breadcrumb_dict(self, **kwargs):
+        """See BaseView.get_breadcrumb_dict.
+        """
         breadcrumb_dict = OrderedDict()
         if self.metadata.get('site') is not None:
+            # If the site is accessible, add /sites/<site name>
+            # to the breadcrumb.
             breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
             breadcrumb_dict[self.metadata['site']['name']] = url_for(
                 'data_dashboard.site_view',
                 uuid=self.metadata['site_id'])
-            breadcrumb_dict[self.human_label+'s'] = url_for(
+            breadcrumb_dict[f'{self.human_label}s'] = url_for(
                 'data_dashboard.cdf_forecast_groups',
                 uuid=self.metadata['site_id'])
         else:
-            breadcrumb_dict[self.human_label+'s'] = url_for(
+            breadcrumb_dict[f'{self.human_label}s'] = url_for(
                 'data_dashboard.cdf_forecast_groups')
         breadcrumb_dict[self.metadata['name']] = url_for(
             'data_dashboard.cdf_forecast_group_view',

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -181,6 +181,7 @@ class SingleObjectView(DataDashView):
 class SingleCDFForecastGroupView(DataDashView):
     template = 'data/cdf_forecast.html'
     metadata_template = 'data/metadata/cdf_forecast_group_metadata.html'
+    human_label = human_friendly_datatype('cdf_forecast')
 
     def get_breadcrumb_dict(self, **kwargs):
         breadcrumb_dict = OrderedDict()
@@ -189,11 +190,11 @@ class SingleCDFForecastGroupView(DataDashView):
             breadcrumb_dict[self.metadata['site']['name']] = url_for(
                 'data_dashboard.site_view',
                 uuid=self.metadata['site_id'])
-            breadcrumb_dict['CDF Forecasts'] = url_for(
+            breadcrumb_dict[self.human_label+'s'] = url_for(
                 'data_dashboard.cdf_forecast_groups',
                 uuid=self.metadata['site_id'])
         else:
-            breadcrumb_dict['CDF Forecasts'] = url_for(
+            breadcrumb_dict[self.human_label+'s'] = url_for(
                 'data_dashboard.cdf_forecast_groups')
         breadcrumb_dict[self.metadata['name']] = url_for(
             'data_dashboard.cdf_forecast_group_view',

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -1,4 +1,7 @@
-from flask import Blueprint, render_template, url_for
+from collections import OrderedDict
+
+
+from flask import Blueprint, render_template, url_for, request
 
 
 from sfa_dash.api_interface import (observations, forecasts,
@@ -11,271 +14,225 @@ from sfa_dash.blueprints.reports import (ReportsView, ReportView,
 from sfa_dash.blueprints.sites import SingleSiteView, SitesListingView
 from sfa_dash.blueprints.util import timeseries_adapter, handle_response
 from sfa_dash.errors import DataRequestException
+from sfa_dash.filters import human_friendly_datatype
 
 
-class SingleObservationView(DataDashView):
+class SingleObjectView(DataDashView):
+    """View for a single data object of type observation, forecast
+    or cdf_forecast.
+    """
     template = 'data/asset.html'
 
-    def breadcrumb_html(self, **kwargs):
-        breadcrumb_format = '/<a href="{url}">{text}</a>'
-        breadcrumb = ''
-        if self.metadata.get('site') is not None:
-            breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.sites'),
-                text='Sites')
-            breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.site_view',
-                            uuid=self.metadata['site_id']),
-                text=self.metadata['site']['name'])
-            breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.observations',
-                            uuid=self.metadata['site_id']),
-                text='Observations')
+    def __init__(self, data_type):
+        """Configures attributes of the view that vary between data type.
+        The `data_type` can be configured when registering a url rule,
+            e.g.
+            <blueprint>.add_url_rule(
+                SingleObjectView.as_view('observations',
+                                         data_type='observation'))
+        Examples can be found at the bottom of this file.
+        """
+        self.data_type = data_type
+        if data_type == 'forecast':
+            self.api_handle = forecasts
+            self.metadata_template = 'data/metadata/forecast_metadata.html'
+            self.id_key = 'forecast_id'
+            self.plot_type = 'forecast'
+        elif data_type == 'observation':
+            self.api_handle = observations
+            self.metadata_template = 'data/metadata/observation_metadata.html'
+            self.id_key = 'observation_id'
+            self.plot_type = 'observation'
+        elif data_type == 'cdf_forecast':
+            self.api_handle = cdf_forecasts
+            self.metadata_template = 'data/metadata/cdf_forecast_metadata.html'
+            self.id_key = 'forecast_id'
+            self.plot_type = 'forecast'
         else:
-            breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.observations'),
-                text='Observations')
+            raise ValueError('Invalid data_type.')
+        self.human_label = human_friendly_datatype(self.data_type)
 
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.observation_view',
-                        uuid=self.metadata['observation_id']),
-            text=self.metadata['name'])
-        return breadcrumb
+    def get_breadcrumb_dict(self):
+        """Creates an Ordered dictionary used for building the page's
+        breadcrumb. Output can be passed to the BaseView.breadcrumb_html
+        function.
+
+        Notes
+        -----
+        The breadcrumb dictionary should be built in the form:
+
+            { "link text": "url", ...}
+
+        Where the order of the keys is rendered from left to right.
+        """
+        breadcrumb_dict = OrderedDict()
+        if self.data_type == 'cdf_forecast':
+            listing_view = 'cdf_forecast_groups'
+        else:
+            listing_view = f'{self.data_type}s'
+        # Insert site link if available
+        if self.metadata.get('site') is not None:
+            breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
+            breadcrumb_dict[self.metadata['site']['name']] = url_for(
+                'data_dashboard.site_view',
+                uuid=self.metadata['site_id'])
+            breadcrumb_dict[self.human_label + 's'] = url_for(
+                f'data_dashboard.{listing_view}',
+                uuid=self.metadata['site_id'])
+        else:
+            breadcrumb_dict[self.human_label + 's'] = url_for(
+                f'data_dashboard.{listing_view}')
+        # Insert a parent link for cdf_forecasts
+        if self.data_type == 'cdf_forecast':
+            breadcrumb_dict[self.metadata['name']] = url_for(
+                f'data_dashboard.cdf_forecast_group_view',
+                uuid=self.metadata['parent'])
+            breadcrumb_dict[self.metadata['constant_value']] = url_for(
+                f'data_dashboard.{self.data_type}_view',
+                uuid=self.metadata[self.id_key])
+        else:
+            breadcrumb_dict[self.metadata['name']] = url_for(
+                f'data_dashboard.{self.data_type}_view',
+                uuid=self.metadata[self.id_key])
+        return breadcrumb_dict
+
+    def set_template_args(self, **kwargs):
+        """Insert necessary template arguments. See data/asset.html in the
+        template folder for how these are layed out.
+        """
+        self.temp_args['current_path'] = request.path
+        self.temp_args['subnav'] = self.format_subnav(**kwargs)
+        self.temp_args['breadcrumb'] = self.breadcrumb_html(
+            self.get_breadcrumb_dict())
+        self.temp_args['metadata'] = render_template(self.metadata_template,
+                                                     **self.metadata)
+        self.temp_args['upload_link'] = url_for(
+            f'forms.upload_{self.data_type}_data',
+            uuid=self.metadata[self.id_key])
+        self.temp_args['download_link'] = url_for(
+            f'forms.download_{self.data_type}_data',
+            uuid=self.metadata[self.id_key])
+        if self.data_type != 'cdf_forecast':
+            self.temp_args['delete_link'] = url_for(
+                f'data_dashboard.delete_{self.data_type}',
+                uuid=self.metadata[self.id_key])
+
+    def insert_plot(self, uuid, start, end):
+        """Generate a plot and bokeh script for the data between
+        start and end. Note that the core library requires a 'site'
+        key with the full site metadata to create a plot.
+        """
+        try:
+            values = handle_response(self.api_handle.get_values(
+                uuid, params={'start': start, 'end': end}))
+        except DataRequestException:
+            self.temp_args.update({'warnings': {
+                'Value Access': [f'{self.human_label} values inaccessible.']},
+            })
+        else:
+            script_plot = timeseries_adapter(
+                self.plot_type, self.metadata, values)
+            if script_plot is None:
+                self.temp_args.update({
+                    'messages': {
+                        'Data': [
+                            (f"No data available for this {self.human_label} "
+                             "during this period.")]},
+                })
+            else:
+                self.temp_args.update({
+                    'plot': script_plot[1],
+                    'bokeh_script': script_plot[0]
+                })
 
     def get(self, uuid, **kwargs):
+        self.temp_args = {}
         start, end = self.parse_start_end_from_querystring()
-        temp_args = {}
-        # fetch observation metadata
+        # Attempt a request for the object's metadata. On an error,
+        # inject the errors into the template arguments and skip
+        # any further processing.
         try:
             self.metadata = handle_response(
-                observations.get_metadata(uuid))
+                self.api_handle.get_metadata(uuid))
         except DataRequestException as e:
-            temp_args.update({'errors': e.errors})
+            self.temp_args.update({'errors': e.errors})
         else:
-            # fetch site metadata
             try:
                 self.metadata['site'] = self.get_site_metadata(
                     self.metadata['site_id'])
             except DataRequestException:
-                temp_args.update({'warnings': {
-                    'Site Access': ['Could not read site.']}})
+                self.temp_args.update({
+                    'warnings': {
+                        'Site Access': [
+                            'Site inaccessible. Plots will not be displayed.']
+                    },
+                    'plot': None,
+                })
             else:
-                try:
-                    values = handle_response(observations.get_values(
-                        uuid, params={'start': start, 'end': end}))
-                except DataRequestException:
-                    temp_args.update({'warnings': {
-                        'Value Access': ['Could not read observation values']}})
-                else:
-                    if len(values) != 0:
-                        script_plot = timeseries_adapter(
-                            'observation', self.metadata, values)
-                        if script_plot is None:
-                            temp_args.update({
-                                'messages':
-                                    {'Data': [
-                                        ("No data available for this Observation "
-                                         "during this period.")]},
-                            })
-                        else:
-                            temp_args.update({'plot': script_plot[1],
-                                              'bokeh_script': script_plot[0]})
+                # If site data is available, try to create a plot
+                self.insert_plot(uuid, start, end)
             finally:
-                temp_args.update(self.template_args(**kwargs))
-
-            self.metadata['site_link'] = self.generate_site_link(self.metadata)
-            temp_args['metadata'] = render_template(
-                'data/metadata/observation_metadata.html',
-                **self.metadata)
-            temp_args['upload_link'] = url_for(
-                'forms.upload_observation_data',
-                uuid=uuid)
-            temp_args['download_link'] = url_for(
-                'forms.download_observation_data',
-                uuid=uuid)
-            temp_args['delete_link'] = url_for(
-                f'data_dashboard.delete_observation',
-                uuid=uuid)
-        return render_template(self.template, **temp_args)
-
-
-class SingleCDFForecastView(DataDashView):
-    template = 'data/asset.html'
-
-    def breadcrumb_html(self, **kwargs):
-        breadcrumb_format = '/<a href="{url}">{text}</a>'
-        breadcrumb = ''
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites'),
-            text='Sites')
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.site_view',
-                        uuid=self.metadata['site_id']),
-            text=self.metadata['site']['name'])
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecast_groups',
-                        uuid=self.metadata['site_id']),
-            text='CDF Forecasts')
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecast_group_view',
-                        uuid=self.metadata['parent']),
-            text=self.metadata['name'])
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecast_view',
-                        uuid=self.metadata['forecast_id']),
-            text=self.metadata['constant_value'])
-        return breadcrumb
-
-    def get(self, uuid, **kwargs):
-        start, end = self.parse_start_end_from_querystring()
-        try:
-            self.metadata = handle_response(
-                cdf_forecasts.get_metadata(uuid))
-            self.metadata['site'] = self.get_site_metadata(
-                self.metadata['site_id'])
-            values = handle_response(cdf_forecasts.get_values(
-                uuid, params={'start': start, 'end': end}))
-        except DataRequestException as e:
-            temp_args = {'errors': e.errors}
-        else:
-            temp_args = self.template_args(**kwargs)
-            if len(values) != 0:
-                script_plot = timeseries_adapter(
-                    'forecast',
-                    self.metadata,
-                    values)
-                if script_plot is None:
-                    temp_args.update(
-                        {'messages':
-                            {'Data': [("No data available for this Forecast "
-                                       "during this period.")]}
-                         }
-                    )
-                else:
-                    temp_args.update({'plot': script_plot[1],
-                                      'bokeh_script': script_plot[0]})
-            self.metadata['site_link'] = self.generate_site_link(self.metadata)
-            temp_args['metadata'] = render_template(
-                'data/metadata/cdf_forecast_metadata.html',
-                **self.metadata)
-            temp_args['upload_link'] = url_for(
-                'forms.upload_cdf_forecast_data',
-                uuid=uuid)
-            temp_args['download_link'] = url_for(
-                'forms.download_cdf_forecast_data',
-                uuid=uuid)
-        return render_template(self.template, **temp_args)
-
-
-class SingleForecastView(DataDashView):
-    template = 'data/asset.html'
-
-    def breadcrumb_html(self, **kwargs):
-        breadcrumb_format = '/<a href="{url}">{text}</a>'
-        breadcrumb = ''
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites'),
-            text='Sites')
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.site_view',
-                        uuid=self.metadata['site_id']),
-            text=self.metadata['site']['name'])
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.forecasts',
-                        uuid=self.metadata['site_id']),
-            text='Forecasts')
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.forecast_view',
-                        uuid=self.metadata['forecast_id']),
-            text=self.metadata['name'])
-        return breadcrumb
-
-    def get(self, uuid, **kwargs):
-        start, end = self.parse_start_end_from_querystring()
-        try:
-            self.metadata = handle_response(
-                forecasts.get_metadata(uuid))
-            self.metadata['site'] = self.get_site_metadata(
-                self.metadata['site_id'])
-            values = handle_response(forecasts.get_values(
-                uuid, params={'start': start, 'end': end}))
-        except DataRequestException as e:
-            temp_args = {'errors': e.errors}
-        else:
-            temp_args = self.template_args(**kwargs)
-            if len(values) != 0:
-                script_plot = timeseries_adapter(
-                    'forecast',
-                    self.metadata,
-                    values)
-                if script_plot is None:
-                    temp_args.update(
-                        {'messages':
-                            {'Data': [("No data available for this Forecast "
-                                       "during this period.")]}
-                         }
-                    )
-                else:
-                    temp_args.update({'plot': script_plot[1],
-                                      'bokeh_script': script_plot[0]})
-            self.metadata['site_link'] = self.generate_site_link(self.metadata)
-            temp_args['metadata'] = render_template(
-                'data/metadata/forecast_metadata.html',
-                **self.metadata)
-            temp_args['upload_link'] = url_for(
-                'forms.upload_forecast_data',
-                uuid=uuid)
-            temp_args['download_link'] = url_for(
-                'forms.download_forecast_data',
-                uuid=uuid)
-            temp_args['delete_link'] = url_for(
-                f'data_dashboard.delete_forecast',
-                uuid=uuid)
-        return render_template(self.template, **temp_args)
+                self.metadata['site_link'] = self.generate_site_link(
+                    self.metadata)
+                self.set_template_args(**kwargs)
+        return render_template(self.template, **self.temp_args)
 
 
 class SingleCDFForecastGroupView(DataDashView):
     template = 'data/cdf_forecast.html'
+    metadata_template = 'data/metadata/cdf_forecast_group_metadata.html'
 
-    def breadcrumb_html(self, **kwargs):
-        breadcrumb_format = '/<a href="{url}">{text}</a>'
-        breadcrumb = ''
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.sites'),
-            text='Sites')
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.site_view',
-                        uuid=self.metadata['site_id']),
-            text=self.metadata['site']['name'])
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecast_groups',
-                        uuid=self.metadata['site_id']),
-            text='CDF Forecasts')
-        breadcrumb += breadcrumb_format.format(
-            url=url_for('data_dashboard.cdf_forecast_group_view',
-                        uuid=self.metadata['forecast_id']),
-            text=self.metadata['name'])
-        return breadcrumb
+    def get_breadcrumb_dict(self, **kwargs):
+        breadcrumb_dict = OrderedDict()
+        if self.metadata.get('site') is not None:
+            breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
+            breadcrumb_dict[self.metadata['site']['name']] = url_for(
+                'data_dashboard.site_view',
+                uuid=self.metadata['site_id'])
+            breadcrumb_dict['CDF Forecasts'] = url_for(
+                'data_dashboard.cdf_forecast_groups',
+                uuid=self.metadata['site_id'])
+        else:
+            breadcrumb_dict['CDF Forecasts'] = url_for(
+                'data_dashboard.cdf_forecast_groups')
+        breadcrumb_dict[self.metadata['name']] = url_for(
+            'data_dashboard.cdf_forecast_group_view',
+            uuid=self.metadata['forecast_id'])
+        return breadcrumb_dict
+
+    def set_template_args(self, **kwargs):
+        """Insert necessary template arguments. See data/asset.html in the
+        template folder for how these are layed out.
+        """
+        self.temp_args['current_path'] = request.path
+        self.temp_args['subnav'] = self.format_subnav(**kwargs)
+        self.temp_args['breadcrumb'] = self.breadcrumb_html(
+            self.get_breadcrumb_dict())
+        self.temp_args['metadata'] = render_template(self.metadata_template,
+                                                     **self.metadata)
+        self.metadata['site_link'] = self.generate_site_link(self.metadata)
+        self.temp_args['constant_values'] = self.metadata['constant_values']
+        self.temp_args['delete_link'] = url_for(
+            f'data_dashboard.delete_cdf_forecast_group',
+            uuid=self.metadata['forecast_id'])
 
     def get(self, uuid, **kwargs):
+        self.temp_args = {}
         try:
             self.metadata = handle_response(
                 cdf_forecast_groups.get_metadata(uuid))
-            self.metadata['site'] = self.get_site_metadata(
-                self.metadata['site_id'])
         except DataRequestException as e:
-            temp_args = {'errors': e.errors}
+            self.temp_args.update({'errors': e.errors})
         else:
-            temp_args = self.template_args(**kwargs)
-            self.metadata['site_link'] = self.generate_site_link(self.metadata)
-            temp_args['metadata'] = self.metadata
-            temp_args['metadata_section'] = render_template(
-                'data/metadata/cdf_forecast_group_metadata.html',
-                **self.metadata)
-            temp_args['delete_link'] = url_for(
-                f'data_dashboard.delete_cdf_forecast_group',
-                uuid=uuid)
-        return render_template(self.template, **temp_args)
+            try:
+                self.metadata['site'] = self.get_site_metadata(
+                    self.metadata['site_id'])
+            except DataRequestException:
+                self.temp_args.update({'warnings': {
+                    'Site Access': ['Site inaccessible.']}})
+        finally:
+            self.set_template_args()
+        return render_template(self.template, **self.temp_args)
 
 
 class AccessView(DataDashView):
@@ -286,29 +243,23 @@ class TrialsView(DataDashView):
     template = 'data/trials.html'
 
 
+# Url Rule Registration
+# The url roles here are broken into sections based on their function.
+# For instance, all views that display a tabulated listing of metadata
+# are grouped under 'Listing pages'. The view names for each section
+# follow a pattern that you should follow when adding new views. The
+# patterns help to ensure predictable arguments when calling the
+# built-in flask url_for() function.
 data_dash_blp = Blueprint('data_dashboard', 'data_dashboard')
 
+# Listing pages
+# view name pattern: '<data_type>s'
 data_dash_blp.add_url_rule(
     '/sites/',
     view_func=SitesListingView.as_view('sites'))
 data_dash_blp.add_url_rule(
-    '/sites/<uuid>/',
-    view_func=SingleSiteView.as_view('site_view'))
-data_dash_blp.add_url_rule(
-    '/sites/<uuid>/<name>/access',
-    view_func=AccessView.as_view('observation_named_access'))
-data_dash_blp.add_url_rule(
-    '/sites/<uuid>/<name>/reports',
-    view_func=ReportsView.as_view('observation_named_reports'))
-data_dash_blp.add_url_rule(
-    '/sites/<uuid>/<name>/trials',
-    view_func=TrialsView.as_view('observation_named_trials'))
-data_dash_blp.add_url_rule(
     '/observations/',
     view_func=DataListingView.as_view('observations', data_type='observation'))
-data_dash_blp.add_url_rule(
-    '/observations/<uuid>',
-    view_func=SingleObservationView.as_view('observation_view'))
 data_dash_blp.add_url_rule(
     '/forecasts/single/',
     view_func=DataListingView.as_view('forecasts', data_type='forecast'))
@@ -317,15 +268,35 @@ data_dash_blp.add_url_rule(
     view_func=DataListingView.as_view('cdf_forecast_groups',
                                       data_type='cdf_forecast_group'))
 data_dash_blp.add_url_rule(
+    '/reports/',
+    view_func=ReportsView.as_view('reports'))
+
+# Views for a single piece of metadata
+# view name pattern: '<data_type>_view'
+data_dash_blp.add_url_rule(
+    '/sites/<uuid>/',
+    view_func=SingleSiteView.as_view('site_view'))
+data_dash_blp.add_url_rule(
+    '/observations/<uuid>',
+    view_func=SingleObjectView.as_view(
+        'observation_view', data_type='observation'))
+data_dash_blp.add_url_rule(
     '/forecasts/single/<uuid>',
-    view_func=SingleForecastView.as_view('forecast_view'))
+    view_func=SingleObjectView.as_view(
+        'forecast_view', data_type='forecast'))
+data_dash_blp.add_url_rule(
+    '/forecasts/cdf/single/<uuid>',
+    view_func=SingleObjectView.as_view(
+        'cdf_forecast_view', data_type='cdf_forecast'))
 data_dash_blp.add_url_rule(
     '/forecasts/cdf/<uuid>',
     view_func=SingleCDFForecastGroupView.as_view('cdf_forecast_group_view'))
 data_dash_blp.add_url_rule(
-    '/forecasts/cdf/single/<uuid>',
-    view_func=SingleCDFForecastView.as_view('cdf_forecast_view'))
+    '/reports/<uuid>',
+    view_func=ReportView.as_view('report_view'))
 
+# Deletion forms
+# View name pattern: 'delete_<data_type>'
 data_dash_blp.add_url_rule(
     '/sites/<uuid>/delete',
     view_func=DeleteConfirmation.as_view('delete_site', data_type='site'))
@@ -341,12 +312,6 @@ data_dash_blp.add_url_rule(
     '/forecasts/cdf/<uuid>/delete',
     view_func=DeleteConfirmation.as_view(
         'delete_cdf_forecast_group', data_type='cdf_forecast_group'))
-data_dash_blp.add_url_rule(
-    '/reports/',
-    view_func=ReportsView.as_view('reports'))
-data_dash_blp.add_url_rule(
-    '/reports/<uuid>',
-    view_func=ReportView.as_view('report_view'))
 data_dash_blp.add_url_rule(
     '/reports/<uuid>/delete',
     view_func=DeleteReportView.as_view('delete_report'))

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -49,8 +49,8 @@ class ReportForm(BaseView):
         }
 
     def zip_object_pairs(self, form_data):
-        """Create a list of observation, forecast tuples from the the
-        (forecast-n, observation-n) input elements inserted by
+        """Create a list of observation, forecast tuples in the form
+        (forecast-n, observation-n) from input elements inserted by
         report-handling.js
         """
         fx = filter_form_fields('forecast-id-', form_data)

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -6,7 +6,7 @@ from requests.exceptions import HTTPError
 from solarforecastarbiter.reports.main import report_to_html_body
 from sfa_dash.api_interface import observations, forecasts, sites, reports
 from sfa_dash.blueprints.base import BaseView
-from sfa_dash.blueprints.util import filter_form_fields
+from sfa_dash.blueprints.util import filter_form_fields, handle_response
 
 
 class ReportsView(BaseView):
@@ -27,16 +27,14 @@ class ReportForm(BaseView):
         """Requests the forecasts and observations from
         the api for injecting into the dom as a js variable
         """
-        observation_request = observations.list_metadata()
-        forecast_request = forecasts.list_metadata()
-        site_request = sites.list_metadata()
-        observation_list = observation_request.json()
+        observation_list = handle_response(
+            observations.list_metadata())
+        forecast_list = handle_response(forecasts.list_metadata())
+        site_list = handle_response(sites.list_metadata())
         for obs in observation_list:
             del obs['extra_parameters']
-        forecast_list = forecast_request.json()
         for fx in forecast_list:
             del fx['extra_parameters']
-        site_list = site_request.json()
         for site in site_list:
             del site['extra_parameters']
         return {

--- a/sfa_dash/blueprints/sites.py
+++ b/sfa_dash/blueprints/sites.py
@@ -33,8 +33,11 @@ class SitesListingView(SiteDashView):
     def get(self, **kwargs):
         # Update kwargs with the create query parameter
         kwargs.update({'create': request.args.get('create')})
-        return render_template(self.template,
-                               **self.get_template_args(**kwargs))
+        try:
+            temp_args = self.get_template_args(**kwargs)
+        except DataRequestException as e:
+            temp_args = {'errors': e.errors}
+        return render_template(self.template, **temp_args)
 
 
 class SingleSiteView(SiteDashView):

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -312,6 +312,7 @@ def handle_response(request_object):
         handled.
     """
     if not request_object.ok:
+        errors = {}
         if request_object.status_code == 400:
             errors = request_object.json()
         elif request_object.status_code == 401:

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -43,7 +43,7 @@ class DataTables(object):
                                     uuid=data['site_id'])
                 site_link = f'<a href={site_href}>{site_name}</a>'
             else:
-                site_link = "Site Unavailable"
+                site_link = 'Site Unavailable'
             table_row['name'] = data['name']
             table_row['variable'] = data['variable']
             table_row['provider'] = data.get('provider', '')
@@ -154,10 +154,14 @@ class DataTables(object):
         table_rows = []
         for data in data_list:
             table_row = {}
-            site_name = site_dict[data['site_id']]['name']
-            site_href = url_for('data_dashboard.site_view',
-                                uuid=data['site_id'])
-            site_link = f'<a href={site_href}>{site_name}</a>'
+            site = site_dict.get(data['site_id'])
+            if site is not None:
+                site_name = site['name']
+                site_href = url_for('data_dashboard.site_view',
+                                    uuid=data['site_id'])
+                site_link = f'<a href={site_href}>{site_name}</a>'
+            else:
+                site_link = 'Site Unavailable'
             table_row['name'] = data['name']
             table_row['variable'] = data['variable']
             table_row['provider'] = data.get('provider', '')

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -284,7 +284,9 @@ def filter_form_fields(prefix, form_data):
 
 
 def handle_response(request_object):
-    """Pass a request object to attempt to parse the response.
+    """Parses the response from a request object. On an a resolvable
+    error, raises a DataRequestException with a default error
+    message.
 
     Parameters
     ----------

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -324,6 +324,9 @@ def handle_response(request_object):
                     f' <a href="{previous_page}">Return to the previous '
                     'page.</a>')
             raise DataRequestException(request_object.status_code, **errors)
+        elif request_object.status_code == 422:
+            errors = {'422': ['Failed to compute aggregate Values']}
+            raise DataRequestException(request_object.status_code, **errors)
         else:
             # Other errors should be due to bugs and not by attempts to reach
             # inaccessible data. Allow exceptions to be raised

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -31,8 +31,7 @@ class DataTables(object):
     def create_table_elements(cls, data_list, id_key, **kwargs):
         """Creates a list of objects to be rendered as table by jinja template
         """
-        sites_list_request = sites.list_metadata()
-        sites_list = sites_list_request.json()
+        sites_list = handle_response(sites.list_metadata())
         site_dict = {site['site_id']: site for site in sites_list}
         table_rows = []
         for data in data_list:
@@ -74,8 +73,8 @@ class DataTables(object):
             new Observation' button.
         """
         creation_link = cls.creation_link('observation', site_id)
-        obs_data_request = observations.list_metadata(site_id=site_id)
-        obs_data = obs_data_request.json()
+        obs_data = handle_response(
+            observations.list_metadata(site_id=site_id))
         rows = cls.create_table_elements(obs_data, 'observation_id', **kwargs)
         rendered_table = render_template(cls.observation_template,
                                          table_rows=rows,
@@ -97,9 +96,16 @@ class DataTables(object):
         string
             Rendered HTML table with search bar and a 'Create
             new Forecast' button.
+
+        Raises
+        ------
+        DataRequestException
+            If a site_id is passed and the user does not have access
+            to that site or some other api error has occurred.
         """
         creation_link = cls.creation_link('forecast', site_id)
-        forecast_data = forecasts.list_metadata(site_id=site_id).json()
+        forecast_data = handle_response(
+            forecasts.list_metadata(site_id=site_id))
         rows = cls.create_table_elements(forecast_data,
                                          'forecast_id',
                                          **kwargs)
@@ -123,11 +129,16 @@ class DataTables(object):
         string
             Rendered HTML table with search bar and a 'Create
             new Probabilistic Forecast' button.
+
+        Raises
+        ------
+        DataRequestException
+            If a site_id is passed and the user does not have access
+            to that site or some other api error has occurred.
         """
         creation_link = cls.creation_link('cdf_forecast_group', site_id)
-        cdf_forecast_request = cdf_forecast_groups.list_metadata(
-            site_id=site_id)
-        cdf_forecast_data = cdf_forecast_request.json()
+        cdf_forecast_data = handle_response(
+            cdf_forecast_groups.list_metadata(site_id=site_id))
         rows = cls.create_cdf_forecast_elements(cdf_forecast_data,
                                                 **kwargs)
         rendered_table = render_template(cls.cdf_forecast_template,
@@ -138,8 +149,7 @@ class DataTables(object):
 
     @classmethod
     def create_cdf_forecast_elements(cls, data_list, **kwargs):
-        sites_list_request = sites.list_metadata()
-        sites_list = sites_list_request.json()
+        sites_list = handle_response(sites.list_metadata())
         site_dict = {site['site_id']: site for site in sites_list}
         table_rows = []
         for data in data_list:
@@ -173,9 +183,14 @@ class DataTables(object):
         string
             The rendered html template, including a table of sites, with search
             bar and 'Create new Site' button.
+
+        Raises
+        ------
+        DataRequestException
+            If a site_id is passed and the user does not have access
+            to that site or some other api error has occurred.
         """
-        site_data_request = sites.list_metadata()
-        site_data = site_data_request.json()
+        site_data = handle_response(sites.list_metadata())
         rows = cls.create_site_table_elements(site_data, create, **kwargs)
         if create is None:
             # If the create argument is present, we don't need a "Create

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -37,10 +37,14 @@ class DataTables(object):
         table_rows = []
         for data in data_list:
             table_row = {}
-            site_name = site_dict[data['site_id']]['name']
-            site_href = url_for('data_dashboard.site_view',
-                                uuid=data['site_id'])
-            site_link = f'<a href={site_href}>{site_name}</a>'
+            site = site_dict.get(data['site_id'])
+            if site is not None:
+                site_name = site_dict[data['site_id']]['name']
+                site_href = url_for('data_dashboard.site_view',
+                                    uuid=data['site_id'])
+                site_link = f'<a href={site_href}>{site_name}</a>'
+            else:
+                site_link = "Site Unavailable"
             table_row['name'] = data['name']
             table_row['variable'] = data['variable']
             table_row['provider'] = data.get('provider', '')

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -304,16 +304,16 @@ def handle_response(request_object):
         If a recoverable 400 level error has been encountered.
         The errors attribute will contain a dict of errors.
     """
-    if request_object.status_code != 200:
+    if not request_object.ok:
         if request_object.status_code == 400:
             errors = request_object.json()
             raise DataRequestException(request_object.status_code, **errors)
-        if request_object.status_code == 401:
+        elif request_object.status_code == 401:
             errors = {
                 '401': "You do not have permission to create this resource."
             }
             raise DataRequestException(request_object.status_code, **errors)
-        if request_object.status_code == 404:
+        elif request_object.status_code == 404:
             previous_page = request.headers.get('Referer', None)
             errors = {'404': (
                 'The requested object could not be found. You may need to '
@@ -324,9 +324,11 @@ def handle_response(request_object):
                     f' <a href="{previous_page}">Return to the previous '
                     'page.</a>')
             raise DataRequestException(request_object.status_code, **errors)
-        # Other errors should be due to bugs and not by attempts to reach
-        # inaccessible data. Allow exceptions to be raised
-        # so that they can be reported to Sentry.
+        else:
+            # Other errors should be due to bugs and not by attempts to reach
+            # inaccessible data. Allow exceptions to be raised
+            # so that they can be reported to Sentry.
+            request_object.raise_for_status()
     if request_object.request.method == 'GET':
         if request_object.headers['Content-Type'] == 'application/json':
             return request_object.json()

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -314,12 +314,10 @@ def handle_response(request_object):
     if not request_object.ok:
         if request_object.status_code == 400:
             errors = request_object.json()
-            raise DataRequestException(request_object.status_code, **errors)
         elif request_object.status_code == 401:
             errors = {
                 '401': "You do not have permission to create this resource."
             }
-            raise DataRequestException(request_object.status_code, **errors)
         elif request_object.status_code == 404:
             previous_page = request.headers.get('Referer', None)
             errors = {'404': (
@@ -330,9 +328,9 @@ def handle_response(request_object):
                 errors['404'] = errors['404'] + (
                     f' <a href="{previous_page}">Return to the previous '
                     'page.</a>')
-            raise DataRequestException(request_object.status_code, **errors)
         elif request_object.status_code == 422:
             errors = {'422': ['Failed to compute aggregate Values']}
+        if errors:
             raise DataRequestException(request_object.status_code, **errors)
         else:
             # Other errors should be due to bugs and not by attempts to reach

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -252,7 +252,7 @@ span.help-text::before {
   border-style: solid;
   border-color: transparent transparent #6c757d transparent;
 }
-ul.error-list, ul.message-list{
+.notification-list{
   list-style: none;
   margin-top: .5rem;
   padding-left: 0;

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -12,7 +12,7 @@
 {% endif %}
 <script src="/static/js/plot-bound-parsing.js"></script>
 {% include "sections/notifications.html" %}
-{% if plot is defined %}
+{% if plot is not none %}
 <div class="row data-plots-wrapper">
 {{ plot | safe }}
 </div>

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -10,13 +10,14 @@
 {% if delete_link is defined %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
-{% include "sections/notifications.html" %}
 <script src="/static/js/plot-bound-parsing.js"></script>
+{% include "sections/notifications.html" %}
 {% if plot is defined %}
 <div class="row data-plots-wrapper">
 {{ plot | safe }}
 </div>
 {% endif %}
+{% if metadata is defined %}
 <div class="form-group mt-3">
 <div class="form-element">
   <label for="start">Start (UTC):</label><br/>
@@ -35,5 +36,5 @@
 <input type="text" id="start" name="start" hidden>
 <input type="text" id="end" name="end" hidden>
 </div>
-
+{% endif %}
 {% endblock %}

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -10,14 +10,12 @@
 {% if delete_link is defined %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
-<script src="/static/js/plot-bound-parsing.js"></script>
 {% include "sections/notifications.html" %}
 {% if plot is not none %}
 <div class="row data-plots-wrapper">
 {{ plot | safe }}
 </div>
-{% endif %}
-{% if plot is not none %}
+<script src="/static/js/plot-bound-parsing.js"></script>
 <div class="form-group mt-3">
 <div class="form-element">
   <label for="start">Start (UTC):</label><br/>

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -17,7 +17,7 @@
 {{ plot | safe }}
 </div>
 {% endif %}
-{% if metadata is defined %}
+{% if plot is not none %}
 <div class="form-group mt-3">
 <div class="form-element">
   <label for="start">Start (UTC):</label><br/>

--- a/sfa_dash/templates/data/cdf_forecast.html
+++ b/sfa_dash/templates/data/cdf_forecast.html
@@ -1,6 +1,6 @@
 {% extends "dash/data.html" %}
 {% block content %}
-{{ metadata_section | safe }}
+{{ metadata | safe }}
 {% if upload_link is defined %}
 <a role="button" class="btn btn-primary btn-sm" href="{{upload_link}}">Upload data</a>
 {% endif %}
@@ -11,13 +11,13 @@
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
 {% include "sections/notifications.html" %}
-{% if 'constant_values' in metadata %}
+{% if constant_values is defined %}
 <div class="bin-list">
   <table>
     <tr>
       <th>Value</th>
     </tr>
-    {% for cdf_bin in metadata['constant_values'] %}
+    {% for cdf_bin in constant_values %}
     <tr>
         <td><a href="{{url_for('data_dashboard.cdf_forecast_view', uuid=cdf_bin['forecast_id'])}}">{{ cdf_bin['constant_value'] }}</a></td>
     </tr>

--- a/sfa_dash/templates/data/cdf_forecast.html
+++ b/sfa_dash/templates/data/cdf_forecast.html
@@ -10,6 +10,7 @@
 {% if delete_link is defined %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
+{% include "sections/notifications.html" %}
 {% if 'constant_values' in metadata %}
 <div class="bin-list">
   <table>

--- a/sfa_dash/templates/data/metadata/data_metadata.html
+++ b/sfa_dash/templates/data/metadata/data_metadata.html
@@ -6,7 +6,11 @@
 {% block metadata %}
 <ul class="data-metadata-fields col-md-6 col-sm-12">
       {{ macro.li('Name', name) }}
-      {{ macro.li('Site', site_link )}}
+      {% if site_link is defined %}
+        {{ macro.li('Site', site_link )}}
+      {% else %}
+        {{ macro.li('Site', site_id)}}
+      {% endif %}
 </ul>
 <ul class="data-metadata-fields col-md-6 col-sm-12">
   {{ macro.li('Variable', variable |convert_varname, variable | var_to_units) }}

--- a/sfa_dash/templates/data/metadata/permission_metadata.html
+++ b/sfa_dash/templates/data/metadata/permission_metadata.html
@@ -7,6 +7,7 @@
     <li><b>Action:</b> {{ permission['action'] }}</li>
     <li><b>Object Type:</b> {{ permission['object_type'] }}</li>
     <li><b>Organization:</b> {{ permission['organization'] }} </li>
+    <li><b>Applies to all:</b> {{ permission['applies_to_all'] }} </li>
 </ul>
 <ul class="data-metadata-fields col-md-6 col-xs-12">
     <li><b>Created:</b> {{ permission['created_at'] | format_datetime }}</li>

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -1,5 +1,7 @@
 {% extends "dash/site.html" %}
 {% block content %}
+{% include "sections/notifications.html" %}
+{% if metadata is defined %}
 {{ metadata | safe }}
 {% block toolbar %}
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', uuid=site_id) }}">Create new Observation</a>
@@ -9,4 +11,5 @@
 
 {% endblock %}
 {{ listing | safe }}
+{% endif %}
 {% endblock %}

--- a/sfa_dash/templates/forms/admin/permissions.html
+++ b/sfa_dash/templates/forms/admin/permissions.html
@@ -7,7 +7,7 @@
   <a class="btn-sm btn-primary" href="{{ url_for("admin.observation_permission") }}">Observation</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.forecast_permission") }}'>Forecasts</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.site_permission") }}'>Sites</a>
-  <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecast Groups</a>
+  <a class="btn-sm btn-primary" href='{{ url_for("admin.cdf_forecast_group_permission") }}'>Probabilistic Forecasts</a>
   <a class="btn-sm btn-primary" href='{{ url_for("admin.report_permission") }}'>Reports</a>
 
 </div>

--- a/sfa_dash/templates/org/obs.html
+++ b/sfa_dash/templates/org/obs.html
@@ -1,5 +1,6 @@
 {% extends "dash/site.html" %}
 {% set sidebar = True %}
 {% block content %}
+{% include "sections/notifications.html" %}
 {{ data_table | safe }}
 {% endblock %}

--- a/sfa_dash/templates/sections/notifications.html
+++ b/sfa_dash/templates/sections/notifications.html
@@ -1,15 +1,25 @@
 {% if messages is defined %}
 <div class="messages">
-  <ul class="message-list">
+  <ul class="message-list notification-list">
     {% for title, message in messages.items() %}
       <li class="alert alert-success"><p><b>{{ title }}: </b>{{ message | join(', ') | safe}}</p></li> 
 	{% endfor %}
   </ul>
 </div>
 {% endif %}
+{% if warnings is defined %}
+<div class="warnings">
+  <ul class="warning-list notification-list">
+      {% for title, warning in warnings.items() %}
+      <li class="alert alert-warning"><p><b>{{ title }}: </b>{{ warning | join(', ') | safe}}</p></li>
+      {% endfor %}
+  </ul>
+</div>
+
+{% endif %}
 {% if errors is defined %}
 <div class="errors">
-  <ul class="error-list">
+  <ul class="error-list notification-list">
       {% for title, error in errors.items() %}
       <li class="alert alert-danger"><p><b>{{ title }}: </b>{{ error | join(', ') | safe}}</p></li>
       {% endfor %}


### PR DESCRIPTION
Handles partial permissions, leaning towards restricting data access. I don't think this is a good long term solution, but a stop gap to some of the errors we've seen recently. Hoping to discuss how we want to handle the possibilities of handling the possibility of impractical state of permissions in the framework. 

This PR does the following:
- Allows listing pages (e.g. `/observations`) to display all readable observations. In the case where the associated site is unreadable, displays 'Site Unavailable'. 
- Catches the error thrown when a user navigates to a listing for a site they do not have access to (e.g. https://dashboard.solarforecastarbiter.org/observations/?uuid=933bc5b8-7e49-11e9-b650-0a580a8003e9 with no access to the UO SRML Ashland, OR site).
 
This does have the side effect of responding with a 404 message when accessing valid data where the associated site or values is not readable. 

Moving forward, I think the dashboard should separately handle data requests and respond to each request with as much information as is available to the user. For instance, viewing an observation for which you lack `read_values` and `read` on the associated site should still yield metadata, and perhaps the uuid of the site (available in the observation metadata) and a message about lack of read_value permissions. This does put a damper on my plans to use the core api module going forward, as it does the work of inserting site metadata into the data objects and raises an HTTPError when either read permission is missing.

I was thinking of creating a spreadsheet mapping permission actions to object types and what practical effects they have in the framework. Might be helpful in creating better documentation for the RBAC system.

related to #135 #136 