### PR TITLE
Add email to user views and tables

### DIFF
--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -24,3 +24,19 @@ def add_role(user_id, role_id):
 def remove_role(user_id, role_id):
     req = delete_request(f'/users/{user_id}/roles/{role_id}')
     return req
+
+
+def get_metadata_by_email(email):
+    req = get_request(f'/users-by-email/{email}')
+    return req
+
+
+def add_role_by_email(email, role_id):
+    req = post_request(f'/users-by-email/{email}/roles/{role_id}',
+                       payload=None)
+    return req
+
+
+def remove_role_by_email(email, role_id):
+    req = delete_request(f'/users-by-email/{email}/roles/{role_id}')
+    return req

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -40,3 +40,8 @@ def add_role_by_email(email, role_id):
 def remove_role_by_email(email, role_id):
     req = delete_request(f'/users-by-email/{email}/roles/{role_id}')
     return req
+
+
+def get_email(user_id):
+    req = get_request(f'/users/{user_id}/email')
+    return req

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -216,6 +216,14 @@ class RoleListing(AdminView):
 class RoleView(AdminView):
     template = 'forms/admin/role.html'
 
+    def get_email(self, user_id):
+        try:
+            email = handle_response(users.get_email(user_id))
+        except DataRequestException:
+            return 'Email Unavailable'
+        else:
+            return email
+
     def get(self, uuid, **kwargs):
         role_table = request.args.get('table', 'permissions')
         try:
@@ -237,7 +245,7 @@ class RoleView(AdminView):
                 k: {'user_id': k,
                     'added_to_user': v,
                     'email': user_map.get(k, {}).get(
-                        'email', 'Email Unavailable'),
+                        'email', self.get_email(k)),
                     'organization': user_map.get(k, {}).get(
                         'organization', 'Organization Unavailable')}
                 for k, v in role['users'].items()}

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -241,14 +241,19 @@ class RoleView(AdminView):
             user_list = users.list_metadata().json()
             user_map = {user['user_id']: user
                         for user in user_list}
-            role['users'] = {
-                uid: {'user_id': uid,
-                      'added_to_user': user,
-                      'email': user_map.get(uid, {}).get(
-                          'email', self.get_email(uid)),
-                      'organization': user_map.get(uid, {}).get(
-                          'organization', 'Organization Unavailable')}
-                for uid, user in role['users'].items()}
+            role_users = {}
+            for uid, user in role['users'].items():
+                user_dict = user_map.get(uid, {})
+                email = user_dict.get('email', None)
+                if email is None:
+                    email = self.get_email(uid)
+                role_users[uid] = {
+                    'user_id': uid,
+                    'added_to_user': user,
+                    'email': email,
+                    'organization': user_dict.get(
+                        'organization', 'Organization Unavailable')}
+            role['users'] = role_users
         return render_template(self.template,
                                role=role,
                                role_table=role_table,

--- a/sfa_dash/blueprints/admin.py
+++ b/sfa_dash/blueprints/admin.py
@@ -242,13 +242,13 @@ class RoleView(AdminView):
             user_map = {user['user_id']: user
                         for user in user_list}
             role['users'] = {
-                k: {'user_id': k,
-                    'added_to_user': v,
-                    'email': user_map.get(k, {}).get(
-                        'email', self.get_email(k)),
-                    'organization': user_map.get(k, {}).get(
-                        'organization', 'Organization Unavailable')}
-                for k, v in role['users'].items()}
+                uid: {'user_id': uid,
+                      'added_to_user': user,
+                      'email': user_map.get(uid, {}).get(
+                          'email', self.get_email(uid)),
+                      'organization': user_map.get(uid, {}).get(
+                          'organization', 'Organization Unavailable')}
+                for uid, user in role['users'].items()}
         return render_template(self.template,
                                role=role,
                                role_table=role_table,

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -331,6 +331,9 @@ a.help-button{
 #provider-header{
     padding: 0;
 }
+#removal-header{
+    width: 6em;
+}
 .btn-th{
     color: #333;
     background-color: #fff;

--- a/sfa_dash/templates/data/metadata/user_metadata.html
+++ b/sfa_dash/templates/data/metadata/user_metadata.html
@@ -4,7 +4,7 @@
 {% block metadata %}
 <ul class="data-metadata-fields col-md-6 col-xs-12">
     <li><b>ID:</b> {{ user['user_id'] }}</li>
-    <li><b>Email:</b> notyetimplemented@solarforecastarbiter.org</li>
+    <li><b>Email: </b>{{ user['email'] }}</li>
     <li ><b>Organization:</b> {{ user['organization'] }} </li>
 </ul>
 <ul class="data-metadata-fields col-md-6 col-xs-12">

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -19,6 +19,9 @@
     <tr>
       <th scope="col">Name</th>
       <th scope="col">Date Added to Permission</th>
+      {% if not permission['applies_to_all'] %}
+      <th scope="col" id="removal-header"></th>
+      {% endif %}
     </tr>
   </thead>
   <tbody>

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -48,7 +48,6 @@
 <table class="role-users-table table results">
   <thead>
     <tr>
-      <th scope="col">User ID</th>
       <th scope="col">Email</th>
       <th scope="col" id="provider-header">
         <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
@@ -62,8 +61,7 @@
     </tr>
     {% for user_id, user in role['users'].items() %}
       <tr>
-          <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user['user_id'] }}</a></td>
-          <td class="email-column"> {{ user['email'] }}</td>
+          <td class="email-column"><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}"> {{ user['email'] }} </a></td>
           <td class="provider-column">{{ user['organization'] }} </td>
           <td><a href={{ url_for('admin.user_role_removal', uuid=user_id, role_id=role['role_id']) }}>Remove</a></td>
       </tr>

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -21,7 +21,7 @@
     <tr>
       <th scope="col">Name</th>
       <th scope="col">Date Added to Role</th>
-      <th scope="col"></th>
+      <th scope="col" id="removal-header"></th>
     </tr>
   </thead>
   <tbody>
@@ -53,7 +53,7 @@
       <th scope="col" id="provider-header">
         <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
       </th>
-      <th scope="col"></th>
+      <th scope="col" id="removal-header"></th>
     </tr>
   </thead>
   <tbody>
@@ -63,7 +63,7 @@
     {% for user_id, user in role['users'].items() %}
       <tr>
           <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user['user_id'] }}</a></td>
-          <td>&lt;email coming soon&gt;</td>
+          <td class="email-column"> {{ user['email'] }}</td>
           <td class="provider-column">{{ user['organization'] }} </td>
           <td><a href={{ url_for('admin.user_role_removal', uuid=user_id, role_id=role['role_id']) }}>Remove</a></td>
       </tr>

--- a/sfa_dash/templates/forms/admin/role_grant.html
+++ b/sfa_dash/templates/forms/admin/role_grant.html
@@ -10,8 +10,8 @@
 <form action="{{ url_for('admin.role_grant', uuid=role['role_id']) }}" method="post" enctype="application/json" id="role-grant-form">
   <div class="form-group">
   <div class="form-element">
-    <label>User ID</label><br/>
-    <input type="text" class="form-control" name="user_id" placeholder="User ID">
+    <label>User Email</label><br/>
+    <input type="email" class="form-control" name="user_email" placeholder="Email">
   </div>
   {{ form.token() }}
   </div>

--- a/sfa_dash/templates/forms/admin/user.html
+++ b/sfa_dash/templates/forms/admin/user.html
@@ -19,7 +19,7 @@
           <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
       </th>
       <th scope="col">Date Added</th>
-      <th scope="col"></th>
+      <th scope="col" id="removal-header"></th>
     </tr>
   </thead>
   <tbody>

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -25,7 +25,7 @@
       {% for user in table_data %}
         <tr>
             <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["user_id"] }}</a></td>
-            <td>&lt;email coming soon&gt;</td>
+            <td>{{ user["email"] }}</td>
             <td class="provider-column">{{ user["organization"] }} </td>
         </tr>
       {% endfor %}

--- a/sfa_dash/templates/forms/admin/users.html
+++ b/sfa_dash/templates/forms/admin/users.html
@@ -10,7 +10,6 @@
 <table class="users-table table results">
   <thead>
     <tr>
-      <th scope="col">User ID</th>
       <th scope="col">Email</th>
       <th scope="col" id="provider-header">
         <button type="button" class="btn btn-th dropdown-toggle" data-toggle="collapse" data-target="#org-filters" >Organization</button>
@@ -24,8 +23,7 @@
     {% if table_data is defined %}
       {% for user in table_data %}
         <tr>
-            <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["user_id"] }}</a></td>
-            <td>{{ user["email"] }}</td>
+            <td><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}">{{ user["email"] }}</a></td>
             <td class="provider-column">{{ user["organization"] }} </td>
         </tr>
       {% endfor %}


### PR DESCRIPTION
Adds emails to tables when available. Changes the "Grant role" page to use email rather than user id.
If we want user email/org to appear on the role's user listing, we'll have to insert it at the API or expose an endpoint with all the user data as discussed in https://github.com/SolarArbiter/solarforecastarbiter-api/issues/154