### PR TITLE
Aggregate forecast listings

### DIFF
--- a/sfa_dash/api_interface/aggregates.py
+++ b/sfa_dash/api_interface/aggregates.py
@@ -14,7 +14,7 @@ def get_metadata(aggregate_id):
 
 
 def get_values(aggregate_id, **kwargs):
-    req = get_request(f'/aggregates/{aggregate_id}/values')
+    req = get_request(f'/aggregates/{aggregate_id}/values', **kwargs)
     return req
 
 

--- a/sfa_dash/api_interface/cdf_forecast_groups.py
+++ b/sfa_dash/api_interface/cdf_forecast_groups.py
@@ -11,9 +11,11 @@ def get_values(forecast_id, **kwargs):
     return req
 
 
-def list_metadata(site_id=None):
+def list_metadata(site_id=None, aggregate_id=None):
     if site_id is not None:
         req = get_request(f'/sites/{site_id}/forecasts/cdf')
+    elif aggregate_id is not None:
+        req = get_request(f'/aggregates/{aggregate_id}/forecasts/cdf')
     else:
         req = get_request('/forecasts/cdf/')
     return req

--- a/sfa_dash/api_interface/forecasts.py
+++ b/sfa_dash/api_interface/forecasts.py
@@ -11,9 +11,11 @@ def get_values(forecast_id, **kwargs):
     return req
 
 
-def list_metadata(site_id=None):
+def list_metadata(site_id=None, aggregate_id=None):
     if site_id is not None:
         req = get_request(f'/sites/{site_id}/forecasts/single')
+    elif aggregate_id is not None:
+        req = get_request(f'/aggregates/{aggregate_id}/forecasts/single')
     else:
         req = get_request('/forecasts/single/')
     return req

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -289,19 +289,6 @@ class AggregateView(BaseView):
             uuid=self.metadata['aggregate_id'])
         return breadcrumb_dict
 
-    def get_subnav_kwargs(self):
-        return {
-            'observations_url': url_for(
-                'data_dashboard.aggregate_view',
-                uuid=self.metadata['aggregate_id']),
-            'forecasts_url': url_for(
-                'data_dashboard.forecasts',
-                aggregate_id=self.metadata['aggregate_id']),
-            'cdf_forecasts_url': url_for(
-                'data_dashboard.cdf_forecast_groups',
-                aggregate_id=self.metadata['aggregate_id']),
-        }
-
     def set_template_args(self):
         self.temp_args.update({
             'metadata': render_template(
@@ -310,7 +297,16 @@ class AggregateView(BaseView):
             'breadcrumb': self.breadcrumb_html(
                 self.get_breadcrumb_dict()),
             'aggregate': self.metadata,
-            'subnav': self.format_subnav(**self.get_subnav_kwargs())
+            'subnav': self.format_subnav(
+                observations_url=url_for(
+                    'data_dashboard.aggregate_view',
+                    uuid=self.metadata['aggregate_id']),
+                forecasts_url=url_for(
+                    'data_dashboard.forecasts',
+                    aggregate_id=self.metadata['aggregate_id']),
+                cdf_forecasts_url=url_for(
+                    'data_dashboard.cdf_forecast_groups',
+                    aggregate_id=self.metadata['aggregate_id']))
         })
 
     def template_args(self):

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -6,6 +6,7 @@ import pandas as pd
 
 from sfa_dash.api_interface import observations, sites, aggregates
 from sfa_dash.blueprints.base import BaseView
+from sfa_dash.blueprints.data_listing import DataListingView
 from sfa_dash.blueprints.util import (filter_form_fields, handle_response,
                                       parse_timedelta, flatten_dict)
 from sfa_dash.errors import DataRequestException
@@ -371,3 +372,25 @@ class DeleteAggregateView(BaseView):
         return redirect(url_for(
             f'data_dashboard.aggregates',
             messages={'delete': ['Success']}))
+
+
+class AggregateForecastsView(DataListingView):
+    def __init__(self, data_type, **kwargs):
+        if data_type == 'forecast':
+            self.table_function = DataTables.get_forecast_table
+        elif data_type == 'cdf_forecast_group':
+            self.table_function = DataTables.get_cdf_forecast_table
+        else:
+            raise Exception
+        self.data_type = data_Type
+
+    def get_breadcrumb_dict(self, aggregate_id):
+        breadcrumb_dict = OrderedDict()
+        breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
+
+
+        try:
+            aggregates.get_metadata(aggregate_id)
+        except DataRequestException:
+            pass
+        

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -108,11 +108,11 @@ class SiteDashView(BaseView):
         temp_args = {}
         subnav_kwargs = {
             'forecasts_url': url_for('data_dashboard.forecasts',
-                                     uuid=self.metadata['site_id']),
+                                     site_id=self.metadata['site_id']),
             'observations_url': url_for('data_dashboard.observations',
-                                        uuid=self.metadata['site_id']),
+                                        site_id=self.metadata['site_id']),
             'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
-                                         uuid=self.metadata['site_id'])
+                                         site_id=self.metadata['site_id'])
         }
         temp_args['subnav'] = self.format_subnav(**subnav_kwargs)
         temp_args['breadcrumb'] = self.breadcrumb_html()

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -1,4 +1,3 @@
-import pdb
 """Flask endpoints for listing Observations, Forecasts and CDF Forecasts.
 Defers actual table creation and rendering to DataTables in the util module.
 """
@@ -6,7 +5,7 @@ from collections import OrderedDict
 from flask import render_template, request, url_for
 
 
-from sfa_dash.api_interface import sites
+from sfa_dash.api_interface import sites, aggregates
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.blueprints.util import DataTables, handle_response
 from sfa_dash.filters import human_friendly_datatype
@@ -38,41 +37,59 @@ class DataListingView(BaseView):
         self.data_type = data_type
 
     def get_breadcrumb_dict(self, **kwargs):
-        """Build the breadcrumb dictionary for the listing page. Depends on properly
-        formatted kwargs.
+        """Build the breadcrumb dictionary for the listing page. If site_id
+        or aggregate_id are passed as key word arguments, prepends the
+        appropriate links. Note that these links depend on the existence of
+        the self.location_data attribute, that should only be set by during
+        a successful fetch of the site/aggregates metadata.
         """
         breadcrumb_dict = OrderedDict()
-        human_label = human_friendly_datatype(self.data_type)       
+        human_label = human_friendly_datatype(self.data_type)
         if 'site_id' in kwargs:
             breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
-            breadcrumb_dict['Site name here!'] = url_for('data_dashboard.site_view',
-                                                         uuid=kwargs['site_id'])
+            breadcrumb_dict[self.location_data['name']] = url_for(
+                'data_dashboard.site_view', uuid=kwargs['site_id'])
         elif 'aggregate_id' in kwargs:
-            breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
-            breadcrumb_dict['Aggregate name here!'] = url_for('data_dashboard.aggregate_view',
-                                                              uuid=kwargs['aggregate_id'])
-        breadcrumb_dict[f'{human_label}s'] = url_for(f'data_dashboard.{self.data_type}s',
-                                                      **kwargs)
+            breadcrumb_dict['Aggregates'] = url_for(
+                'data_dashboard.aggregates')
+            breadcrumb_dict[self.location_data['name']] = url_for(
+                'data_dashboard.aggregate_view', uuid=kwargs['aggregate_id'])
+        breadcrumb_dict[f'{human_label}s'] = url_for(
+            f'data_dashboard.{self.data_type}s', **kwargs)
         return breadcrumb_dict
-        
+
+    def get_subnav_kwargs(self, **kwargs):
+        """Creates a dict to be used when formating the sub navigation. The
+        resulting dict is used to format the fstring keys found in the
+        DataListingView.subnav_format variable.
+        """
+        subnav_kwargs = {}
+        if 'aggregate_id' in kwargs:
+            subnav_kwargs['observations_url'] = url_for(
+                'data_dashboard.aggregate_view', uuid=kwargs['aggregate_id'])
+        else:
+            subnav_kwargs['observations_url'] = url_for(
+                'data_dashboard.observations', **kwargs)
+        subnav_kwargs['forecasts_url'] = url_for(
+            'data_dashboard.forecasts', **kwargs)
+        subnav_kwargs['cdf_forecasts_url'] = url_for(
+            'data_dashboard.cdf_forecast_groups', **kwargs)
+        return subnav_kwargs
+
     def get_template_args(self, **kwargs):
-        """Create a dictionary containing the required arguments for the template
+        """Create a dictionary containing the required arguments for the
+        template. Special keyword arguments of `site_id` or `aggregate_id` can
+        be passed to filter results by a site or aggregate.
         """
         template_args = {}
-        subnav_kwargs = {
-            'observations_url': url_for('data_dashboard.observations',
-                                        **kwargs),
-            'forecasts_url': url_for('data_dashboard.forecasts',
-                                     **kwargs),
-            'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
-                                         **kwargs)
-        }
-        template_args['subnav'] = self.format_subnav(**subnav_kwargs)
+        template_args['subnav'] = self.format_subnav(
+            **self.get_subnav_kwargs(**kwargs))
         template_args['data_table'] = self.table_function(**kwargs)
         template_args['current_path'] = request.path
         # If kwargs is not empty, a site_id or aggregate_id was passed
         if kwargs:
-            template_args['breadcrumb'] = self.breadcrumb_html(self.get_breadcrumb_dict(**kwargs))
+            template_args['breadcrumb'] = self.breadcrumb_html(
+                self.get_breadcrumb_dict(**kwargs))
         else:
             template_args['page_title'] = 'Forecasts and Observations'
         return template_args
@@ -80,15 +97,25 @@ class DataListingView(BaseView):
     def get(self):
         """
         """
-        # Check for a uuid parameter indicating we should filter by site.
-        # otherwise, set the create key to pass as a query parameter to
-        # the site listing page.
+        # Check for a site id or aggregate id in the query parameters.If found,
+        # sets location_id and api_handle to later request metadata of the site
+        # or aggregate and adds the id to a key word argument dict to be passed
+        # to other setup functions.
         template_kwargs = {}
         if 'site_id' in request.args:
-            template_kwargs.update({'site_id': request.args.get('site_id')})
+            location_id = request.args.get('site_id')
+            api_handle = sites
+            template_kwargs.update({'site_id': location_id})
         elif 'aggregate_id' in request.args:
-            template_kwargs.update({'aggregate_id': request.args.get('aggregate_id')})
+            location_id = request.args.get('aggregate_id')
+            template_kwargs.update({'aggregate_id': location_id})
+            api_handle = aggregates
+        else:
+            api_handle = None
         try:
+            if api_handle:
+                self.location_data = handle_response(
+                    api_handle.get_metadata(location_id))
             temp_args = self.get_template_args(**template_kwargs)
         except DataRequestException as e:
             temp_args = {'errors': e.errors}

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -1,11 +1,15 @@
+import pdb
 """Flask endpoints for listing Observations, Forecasts and CDF Forecasts.
 Defers actual table creation and rendering to DataTables in the util module.
 """
+from collections import OrderedDict
 from flask import render_template, request, url_for
 
+
+from sfa_dash.api_interface import sites
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.blueprints.util import DataTables, handle_response
-from sfa_dash.api_interface import sites
+from sfa_dash.filters import human_friendly_datatype
 
 from sfa_dash.errors import DataRequestException
 
@@ -33,60 +37,59 @@ class DataListingView(BaseView):
             raise Exception
         self.data_type = data_type
 
-    def breadcrumb_html(self, site_id=None, organization=None, **kwargs):
-        breadcrumb_format = '/<a href="{url}">{text}</a>'
-        breadcrumb = ''
-        if self.data_type == 'cdf_forecast_group':
-            type_label = 'CDF Forecast'
-        else:
-            type_label = self.data_type.title()
-        if site_id is not None:
-            site_metadata = handle_response(
-                sites.get_metadata(site_id))
-            breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.sites'),
-                text='Sites')
-            breadcrumb += breadcrumb_format.format(
-                url=url_for('data_dashboard.site_view', uuid=site_id),
-                text=site_metadata['name'])
-        breadcrumb += breadcrumb_format.format(
-            url=url_for(f'data_dashboard.{self.data_type}s', uuid=site_id),
-            text=type_label)
-        return breadcrumb
-
+    def get_breadcrumb_dict(self, **kwargs):
+        """Build the breadcrumb dictionary for the listing page. Depends on properly
+        formatted kwargs.
+        """
+        breadcrumb_dict = OrderedDict()
+        human_label = human_friendly_datatype(self.data_type)       
+        if 'site_id' in kwargs:
+            breadcrumb_dict['Sites'] = url_for('data_dashboard.sites')
+            breadcrumb_dict['Site name here!'] = url_for('data_dashboard.site_view',
+                                                         uuid=kwargs['site_id'])
+        elif 'aggregate_id' in kwargs:
+            breadcrumb_dict['Aggregates'] = url_for('data_dashboard.aggregates')
+            breadcrumb_dict['Aggregate name here!'] = url_for('data_dashboard.aggregate_view',
+                                                              uuid=kwargs['aggregate_id'])
+        breadcrumb_dict[f'{human_label}s'] = url_for(f'data_dashboard.{self.data_type}s',
+                                                      **kwargs)
+        return breadcrumb_dict
+        
     def get_template_args(self, **kwargs):
         """Create a dictionary containing the required arguments for the template
         """
         template_args = {}
-        uuid = request.args.get('uuid')
         subnav_kwargs = {
             'observations_url': url_for('data_dashboard.observations',
-                                        uuid=uuid),
+                                        **kwargs),
             'forecasts_url': url_for('data_dashboard.forecasts',
-                                     uuid=uuid),
+                                     **kwargs),
             'cdf_forecasts_url': url_for('data_dashboard.cdf_forecast_groups',
-                                         uuid=uuid)
+                                         **kwargs)
         }
         template_args['subnav'] = self.format_subnav(**subnav_kwargs)
         template_args['data_table'] = self.table_function(**kwargs)
         template_args['current_path'] = request.path
-        if uuid is not None:
-            template_args['breadcrumb'] = self.breadcrumb_html(**kwargs)
+        # If kwargs is not empty, a site_id or aggregate_id was passed
+        if kwargs:
+            template_args['breadcrumb'] = self.breadcrumb_html(self.get_breadcrumb_dict(**kwargs))
         else:
             template_args['page_title'] = 'Forecasts and Observations'
         return template_args
 
-    def get(self, **kwargs):
+    def get(self):
         """
         """
         # Check for a uuid parameter indicating we should filter by site.
         # otherwise, set the create key to pass as a query parameter to
         # the site listing page.
-        uuid = request.args.get('uuid')
-        if uuid is not None:
-            kwargs.update({'site_id': uuid})
+        template_kwargs = {}
+        if 'site_id' in request.args:
+            template_kwargs.update({'site_id': request.args.get('site_id')})
+        elif 'aggregate_id' in request.args:
+            template_kwargs.update({'aggregate_id': request.args.get('aggregate_id')})
         try:
-            temp_args = self.get_template_args(**kwargs)
+            temp_args = self.get_template_args(**template_kwargs)
         except DataRequestException as e:
             temp_args = {'errors': e.errors}
         return render_template(self.template, **temp_args)

--- a/sfa_dash/blueprints/sites.py
+++ b/sfa_dash/blueprints/sites.py
@@ -17,24 +17,18 @@ class SitesListingView(SiteDashView):
             text='Sites')
         return breadcrumb
 
-    def get_template_args(self, create=None, **kwargs):
+    def get_template_args(self):
         """Create a dictionary containing the required arguments for the template
         """
         template_args = {}
-        template_args['data_table'] = DataTables.get_site_table(create=create,
-                                                                **kwargs)
+        template_args['data_table'] = DataTables.get_site_table()
         template_args['current_path'] = request.path
-        if create is not None:
-            template_args['page_title'] = f"Select a Site"
-        else:
-            template_args['breadcrumb'] = self.breadcrumb_html(**kwargs)
+        template_args['breadcrumb'] = self.breadcrumb_html()
         return template_args
 
-    def get(self, **kwargs):
-        # Update kwargs with the create query parameter
-        kwargs.update({'create': request.args.get('create')})
+    def get(self):
         try:
-            temp_args = self.get_template_args(**kwargs)
+            temp_args = self.get_template_args()
         except DataRequestException as e:
             temp_args = {'errors': e.errors}
         return render_template(self.template, **temp_args)

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -1,3 +1,4 @@
+import pdb
 """ Utility classes/functions. Mostly for handling api data.
 """
 from copy import deepcopy
@@ -21,9 +22,11 @@ class DataTables(object):
     cdf_forecast_template = 'data/table/cdf_forecast_table.html'
 
     @classmethod
-    def creation_link(cls, data_type, site_id=None):
+    def creation_link(cls, data_type, site_id=None, aggregate_id=None):
         if site_id is not None:
             return url_for(f'forms.create_{data_type}', uuid=site_id)
+        elif aggregate_id is not None:
+            return url_for(f'forms.create_aggregate_{data_type}', uuid=aggregat_id)
         else:
             return None
 
@@ -130,7 +133,7 @@ class DataTables(object):
         return rendered_table
 
     @classmethod
-    def get_forecast_table(cls, site_id=None, **kwargs):
+    def get_forecast_table(cls, site_id=None, aggregate_id=None, **kwargs):
         """Generates an html element containing a table of Forecasts
 
         Parameters
@@ -150,9 +153,17 @@ class DataTables(object):
             If a site_id is passed and the user does not have access
             to that site or some other api error has occurred.
         """
-        creation_link = cls.creation_link('forecast', site_id)
+        request_kwargs = {}
+        if site_id is not None:
+            creation_link = cls.creation_link('forecast', site_id)
+            request_kwargs['site_id'] = site_id
+        elif aggregate_id is not None:
+            creation_link = cls.creation_link('forecast', aggregate_id)
+            request_kwargs['aggregate_id'] = aggregate_id
+        else:
+            creation_link = None
         forecast_data = handle_response(
-            forecasts.list_metadata(site_id=site_id))
+            forecasts.list_metadata(**request_kwargs))
         rows = cls.create_table_elements(
             forecast_data,
             'forecast_id',

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -34,7 +34,7 @@ class DataTables(object):
             return None
 
     @classmethod
-    def create_table_elements(cls, data_list, id_key, view_name, **kwargs):
+    def create_table_elements(cls, data_list, id_key, view_name):
         """Creates a list of objects to be rendered as table by jinja template
         """
         sites_list = handle_response(sites.list_metadata())
@@ -76,7 +76,7 @@ class DataTables(object):
         return table_rows
 
     @classmethod
-    def create_site_table_elements(cls, data_list, **kwargs):
+    def create_site_table_elements(cls, data_list):
         """Creates a dictionary to feed to the Site table template as the
         `table_rows` parameter.
 
@@ -104,7 +104,7 @@ class DataTables(object):
         return table_rows
 
     @classmethod
-    def get_observation_table(cls, site_id=None, **kwargs):
+    def get_observation_table(cls, site_id=None, aggregate_id=None):
         """Generates an html element containing a table of Observations
 
         Parameters
@@ -124,16 +124,14 @@ class DataTables(object):
         rows = cls.create_table_elements(
             obs_data,
             'observation_id',
-            'data_dashboard.observation_view',
-            **kwargs)
+            'data_dashboard.observation_view')
         rendered_table = render_template(cls.observation_template,
                                          table_rows=rows,
-                                         creation_link=creation_link,
-                                         **kwargs)
+                                         creation_link=creation_link)
         return rendered_table
 
     @classmethod
-    def get_forecast_table(cls, site_id=None, aggregate_id=None, **kwargs):
+    def get_forecast_table(cls, site_id=None, aggregate_id=None):
         """Generates an html element containing a table of Forecasts
 
         Parameters
@@ -153,33 +151,26 @@ class DataTables(object):
             If a site_id is passed and the user does not have access
             to that site or some other api error has occurred.
         """
-        request_kwargs = {}
-        if site_id is not None:
-            creation_link = cls.creation_link('forecast',
-                                              site_id=site_id)
-            request_kwargs['site_id'] = site_id
-        elif aggregate_id is not None:
-            creation_link = cls.creation_link('forecast',
-                                              aggregate_id=aggregate_id)
-            request_kwargs['aggregate_id'] = aggregate_id
+        if site_id is not None or aggregate_id is not None:
+            creation_link = cls.creation_link(
+                'forecast', site_id=site_id, aggregate_id=aggregate_id)
         else:
             creation_link = None
 
         forecast_data = handle_response(
-            forecasts.list_metadata(**request_kwargs))
+            forecasts.list_metadata(site_id=site_id,
+                                    aggregate_id=aggregate_id))
         rows = cls.create_table_elements(
             forecast_data,
             'forecast_id',
-            'data_dashboard.forecast_view',
-            **kwargs)
+            'data_dashboard.forecast_view')
         rendered_table = render_template(cls.forecast_template,
                                          table_rows=rows,
-                                         creation_link=creation_link,
-                                         **kwargs)
+                                         creation_link=creation_link)
         return rendered_table
 
     @classmethod
-    def get_cdf_forecast_table(cls, site_id=None, aggregate_id=None, **kwargs):
+    def get_cdf_forecast_table(cls, site_id=None, aggregate_id=None):
         """Generates an html element containing a table of CDF Forecasts.
 
         Parameters
@@ -199,33 +190,27 @@ class DataTables(object):
             If a site_id is passed and the user does not have access
             to that site or some other api error has occurred.
         """
-        request_kwargs = {}
-        if site_id is not None:
-            creation_link = cls.creation_link('cdf_forecast_group',
-                                              site_id=site_id)
-            request_kwargs['site_id'] = site_id
-        elif aggregate_id is not None:
-            creation_link = cls.creation_link('cdf_forecast_group',
-                                              aggregate_id=aggregate_id)
-            request_kwargs['aggregate_id'] = aggregate_id
+        if site_id is not None or aggregate_id is not None:
+            creation_link = cls.creation_link(
+                'cdf_forecast_group',
+                site_id=site_id,
+                aggregate_id=aggregate_id)
         else:
             creation_link = None
-
         cdf_forecast_data = handle_response(
-            cdf_forecast_groups.list_metadata(**request_kwargs))
+            cdf_forecast_groups.list_metadata(site_id=site_id,
+                                              aggregate_id=aggregate_id))
         rows = cls.create_table_elements(
             cdf_forecast_data,
             'forecast_id',
-            'data_dashboard.cdf_forecast_group_view',
-            **kwargs)
+            'data_dashboard.cdf_forecast_group_view')
         rendered_table = render_template(cls.cdf_forecast_template,
                                          table_rows=rows,
-                                         creation_link=creation_link,
-                                         **kwargs)
+                                         creation_link=creation_link)
         return rendered_table
 
     @classmethod
-    def get_site_table(cls, **kwargs):
+    def get_site_table(cls):
         """Generates an html element containing a table of Sites.
 
         Returns
@@ -241,7 +226,7 @@ class DataTables(object):
             to that site or some other api error has occurred.
         """
         site_data = handle_response(sites.list_metadata())
-        rows = cls.create_site_table_elements(site_data, **kwargs)
+        rows = cls.create_site_table_elements(site_data)
         creation_link = url_for('forms.create_site')
         rendered_table = render_template(cls.site_template,
                                          creation_link=creation_link,

--- a/sfa_dash/templates/dash/aggregates.html
+++ b/sfa_dash/templates/dash/aggregates.html
@@ -23,7 +23,7 @@
         <td class="aggregates-table-name-column">
           <a href="{{ url_for('data_dashboard.aggregate_view', uuid=agg['aggregate_id']) }}">{{ agg['name'] }}</a>
         </td>
-        <td class="aggregates-table variable-column">{{ agg['variable'] }}</td>
+        <td class="aggregates-table variable-column">{{ agg['variable'] | convert_varname }}</td>
         <td class="aggregates-table provider-column">{{ agg['provider'] }}</td>
     </tr>
   {% endfor %}

--- a/sfa_dash/tests/views/test_success.py
+++ b/sfa_dash/tests/views/test_success.py
@@ -7,7 +7,14 @@ def test_get_no_arg_routes(client, no_arg_route):
 
 
 def test_site_filtered_no_args(client, no_arg_route, site_id):
-    resp = client.get(no_arg_route, base_url=BASE_URL, data={'uuid': site_id})
+    resp = client.get(no_arg_route, base_url=BASE_URL,
+                      data={'site_id': site_id})
+    assert resp.status_code == 200
+
+
+def test_aggregate_filtered_no_args(client, no_arg_route, aggregate_id):
+    resp = client.get(no_arg_route, base_url=BASE_URL,
+                      data={'aggregate_id': aggregate_id})
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
Adds ability to list forecasts or cdf forecasts made for an aggregate, and adds the same subnav as found on sites to aggregates except that the 'observations' link returns the aggregate page, where the listing of constituent observations can be found. 
Like so:
![Screenshot from 2019-11-13 11-06-16](https://user-images.githubusercontent.com/21206164/68791022-af11bd80-0605-11ea-84f9-fc679ba8b554.png)
