### PR TITLE
allow forecast-aggregate pair selection on report form

### DIFF
--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -44,7 +44,7 @@ class DeleteConfirmation(DataDashView):
             self.metadata = handle_response(
                 self.api_handle.get_metadata(uuid))
         except DataRequestException as e:
-            return render_template(self.template, errors=e.errors)
+            return render_template(self.template, uuid=uuid, errors=e.errors)
         else:
             self.temp_args = {}
             try:

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -1,3 +1,4 @@
+import pdb
 """Draft of reports endpoints/pages. Need to integrate core report generation.
 """
 from flask import request, redirect, url_for, render_template
@@ -65,8 +66,9 @@ class ReportForm(BaseView):
         # appropriately indexed forecast.
         truth_ids = filter_form_fields('truth-id-', form_data)
         truth_types = filter_form_fields('truth-type-', form_data)
-        pair_list = list(zip(fx, truth_types, truth_ids))
-        pairs = [{'forecast': p[0], p[1]: p[2]} for p in pair_list]
+        pdb.set_trace()
+        pairs = [{'forecast': f, truth_types[i]: truth_ids[i]}
+                 for i, f in enumerate(fx)]
         return pairs
 
     def parse_metrics(self, form_data):

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -134,7 +134,15 @@ class ReportView(BaseView):
                 'bokeh_script': True}
 
     def get(self, uuid):
-        self.metadata = reports.get_metadata(uuid)
+        try:
+            self.metadata = reports.get_metadata(uuid)
+        except ValueError as e:
+            # Core threw an error trying to calculate the report
+            errors = {
+                'Access': ['Report could not be loaded in the failed state.'],
+                'errors': [str(e)],
+            }
+            return render_template(self.template, uuid=uuid, errors=errors)
         return super().get()
 
 
@@ -153,9 +161,17 @@ class DeleteReportView(BaseView):
             ),
         }
 
-    def get(self, uuid, **kwargs):
-        self.metadata = reports.get_metadata(uuid)
-        return super().get(**kwargs)
+    def get(self, uuid):
+        try:
+            self.metadata = reports.get_metadata(uuid)
+        except ValueError as e:
+            errors = {
+                'Access': ['Report could not be loaded in the failed state.'],
+                'Report Computation': [str(e)],
+            }
+            return render_template(self.template, data_type='report',
+                                   uuid=uuid, errors=errors)
+        return super().get()
 
     def post(self, uuid):
         confirmation_url = url_for(f'data_dashboard.delete_report',

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -1,4 +1,3 @@
-import pdb
 """Draft of reports endpoints/pages. Need to integrate core report generation.
 """
 from flask import request, redirect, url_for, render_template
@@ -66,7 +65,6 @@ class ReportForm(BaseView):
         # appropriately indexed forecast.
         truth_ids = filter_form_fields('truth-id-', form_data)
         truth_types = filter_form_fields('truth-type-', form_data)
-        pdb.set_trace()
         pairs = [{'forecast': f, truth_types[i]: truth_ids[i]}
                  for i, f in enumerate(fx)]
         return pairs

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -299,7 +299,7 @@ $(document).ready(function() {
         var fxVariableSelector = createVariableSelect();
         fxSelector.find('.report-field-filters').append(fxVariableSelector);
         var addObsButton = $('<a role="button" class="btn btn-primary" id="add-obs-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
-        var addAggButton = $('<a role="button" class="btn btn-primary" id="add-agg-object-pair" style="padding-left: 1em">Add a Forecast, aggregate pair</a>');
+        var addAggButton = $('<a role="button" class="btn btn-primary" id="add-agg-object-pair" style="padding-left: 1em">Add a Forecast, Aggregate pair</a>');
 
 
         // Radio button for selecting between an aggregate or site

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -197,7 +197,7 @@ $(document).ready(function() {
             compareTo = $(`[name=observation-aggregate-radio]:checked`).val();
             if (compareTo == 'observation'){
                 selectedSite = $('#site-select :selected');
-                site_id = selectedSite.attr('data-site-id');
+                site_id = selectedSite.data('site-id');
                 if (site_id){
                     $('#no-forecast-site-selection').attr('hidden', true);
                 } else {
@@ -240,9 +240,13 @@ $(document).ready(function() {
             aggregates.removeAttr('hidden');
             selectedForecast = $('#forecast-select :selected');
             if (selectedForecast.length){
-                aggregate_id = selectedForecast.attr('data-aggregate-id');
+                aggregate_id = selectedForecast.data('aggregate-id');
                 toHide = searchSelect('#aggregate-option-search', '#aggregate-select', 1);
                 toHide = toHide.add(aggregates.not(`[data-aggregate-id=${aggregate_id}]`));
+                current_interval = selectedForecast.data('interval-length');
+                toHide = toHide.add(aggregates.filter(function(){
+                    return parseInt(this.dataset['intervalLength']) > current_interval;
+                }));
                 if ((toHide.length == aggregates.length) && aggregate_id){
                     $('#no-aggregates').removeAttr('hidden');
                 } else {
@@ -264,8 +268,8 @@ $(document).ready(function() {
                 // Show all of the observations
                 observations.removeAttr('hidden');
                 // retrieve the current site id and variable from the selected forecast
-                site_id = selectedForecast.attr('data-site-id');
-                variable = selectedForecast.attr('data-variable');
+                site_id = selectedForecast.data('site-id');
+                variable = selectedForecast.data('variable');
                 $('#no-observation-forecast-selection').attr('hidden', true);
 
                 // Build the list of optiosn to hide by creating a set from
@@ -273,6 +277,10 @@ $(document).ready(function() {
                 var toHide = searchSelect('#observation-option-search', '#observation-select', 2);
                 toHide = toHide.add(observations.not(`[data-site-id=${site_id}]`));
                 toHide = toHide.add(observations.not(`[data-variable=${variable}]`));
+                current_interval = selectedForecast.data('interval-length');
+                toHide = toHide.add(observations.filter(function(){
+                    return parseInt(this.dataset['intervalLength']) > current_interval
+                }));
                 toHide.attr('hidden', true);
                 // if the current selection is hidden, deselect it
                 if (toHide.filter(':selected').length){
@@ -355,6 +363,7 @@ $(document).ready(function() {
                     .val(this.observation_id)
                     .attr('hidden', true)
                     .attr('data-site-id', this.site_id)
+                    .attr('data-interval-length', this.interval_length)
                     .attr('data-variable', this.variable));
         });
         $.each(page_data['forecasts'], function(){
@@ -365,6 +374,7 @@ $(document).ready(function() {
                     .attr('hidden', true)
                     .attr('data-site-id', this.site_id)
                     .attr('data-aggregate-id', this.aggregate_id)
+                    .attr('data-interval-length', this.interval_length)
                     .attr('data-variable', this.variable));
         });
         $.each(page_data['aggregates'], function(){
@@ -374,6 +384,7 @@ $(document).ready(function() {
                     .val(this.aggregate_id)
                     .attr('hidden', true)
                     .attr('data-aggregate-id', this.aggregate_id)
+                    .attr('data-interval-length', this.interval_length)
                     .attr('data-variable', this.variable));
         });
         

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -50,7 +50,6 @@ $(document).ready(function() {
         return variable_select
     }
 
-
     function searchSelect(inputSelector, selectSelector, offset=0){
         /*
          * Retrieves the value the <input> element identified by inputSelector and
@@ -63,15 +62,15 @@ $(document).ready(function() {
         return $(selectSelector + " option").slice(offset).not(":containsi('" + searchSplit + "')");
     }
 
-
-    function addPair(obsName, obsId, fxName, fxId){
+    function addPair(truthType, truthName, truthId, fxName, fxId){
         /*
-         * Returns a Jquery object containing 4 input elements representing a forecast,
+         * Returns a Jquery object containing 5 input elements representing a forecast,
          * observation pair:
          *  forecast-name-<index>
          *  forecast-id-<index>
-         *  observation-name-<indeX>
-         *  observation-id-<indeX>
+         *  truth-name-<indeX>
+         *  truth-id-<indeX>
+         *  truth-type-<index>
          *  where index associates the pairs with eachother for easier parsing when the form
          *  is submitted.
          */
@@ -82,8 +81,9 @@ $(document).ready(function() {
                     <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
                   </div>
                   <div class="col-md-6">
-                    <input type="text" class="form-control observation-field" name="observation-name-${pair_index}"  required disabled value="${obsName}"/>
-                    <input type="hidden" class="form-control observation-field" name="observation-id-${pair_index}" required value="${obsId}"/>
+                    <input type="text" class="form-control truth-field" name="truth-name-${pair_index}"  required disabled value="${truthName}"/>
+                    <input type="hidden" class="form-control truth-field" name="truth-id-${pair_index}" required value="${truthId}"/>
+                    <input type="hidden" class="form-control truth-field" name="truth-type-${pair_index}" required value="${truthType}"/>
                   </div>
                  </div>
                  <a role="button" class="object-pair-delete-button">x</a>
@@ -111,7 +111,7 @@ $(document).ready(function() {
                       <div class="report-field-filters"><input id="${field_type}-option-search" class="form-control half-width" placeholder="Search by ${field_type} name"/></div><br>
                     <div class="input-wrapper">
                       <select id="${field_type}-select" class="form-control ${field_type}-field" name="${field_type}-select" size="5">
-                      ${depends_on ? `<option id="no-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
+                      ${depends_on ? `<option id="no-${field_type}-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
                       <option id="no-${field_type}s" disabled hidden>No matching ${field_type}s</option>
                     </select>
                     </div>
@@ -145,43 +145,116 @@ $(document).ready(function() {
             toHide.attr('hidden', true);
         }
 
+        function determineWidgets(){
+            /*
+             * Based on the value of the observation-aggregate-radio button,
+             * display the correct select lists and set up the correct
+             * parsing of values into object-pairs.
+             */
+            compareTo = $(`[name=observation-aggregate-radio]:checked`).val();
+            if (compareTo == 'observation'){
+                // hide aggregates
+                // show sites & observations
+                $('.aggregate-select-wrapper').attr('hidden', true);
+                $('.site-select-wrapper').removeAttr('hidden');
+                $('.observation-select-wrapper').removeAttr('hidden');
+                $('#aggregate-select').val('');
+                $("#add-obs-object-pair").removeAttr('hidden');
+                $("#add-agg-object-pair").attr('hidden', true);
+                filterForecasts();
+            } else {
+                // hide sites & observations
+                // show aggregates
+                $('.site-select-wrapper').attr('hidden', true);
+                $('.observation-select-wrapper').attr('hidden', true);
+                $('.aggregate-select-wrapper').removeAttr('hidden');
+                $('#site-select').val('');
+                $("#add-agg-object-pair").removeAttr('hidden');
+                $("#add-obs-object-pair").attr('hidden', true);
+
+                filterForecasts();
+            }
+            return compareTo
+
+        }
 
         function filterForecasts(){
             /*
              * Hide options in the forecast selector based on the currently selected
              * site and variable.
              */
+            // Show all Forecasts
             forecasts = $('#forecast-select option').slice(2);
             forecasts.removeAttr('hidden');
 
-            selectedSite = $('#site-select :selected');
-            site_id = selectedSite.attr('data-site-id');
-            $('#no-site-selection').attr('hidden', true);
+            toHide = searchSelect('#forecast-option-search', '#forecast-select', 2);
             variable_select = $('#variable-select');
             variable = variable_select.val();
-
-            // create a set of elements to hide from selected site, variable and search
-            var toHide = forecasts.not(`[data-site-id=${site_id}]`);
             if (variable){
                 toHide = toHide.add(forecasts.not(`[data-variable=${variable}]`));
             }
-            toHide = toHide.add(searchSelect('#forecast-option-search', '#forecast-select', 2));
-            toHide.attr('hidden', 'true');
+            // Determine if we need to filter by site or aggregate
+            compareTo = $(`[name=observation-aggregate-radio]:checked`).val();
+            if (compareTo == 'observation'){
+                selectedSite = $('#site-select :selected');
+                site_id = selectedSite.attr('data-site-id');
+                if (site_id){
+                    $('#no-forecast-site-selection').attr('hidden', true);
+                } else {
+                    $('#no-forecast-site-selection').removeAttr('hidden');
+                }
+                // create a set of elements to hide from selected site, variable and search
+                toHide = toHide.add(forecasts.not(`[data-site-id=${site_id}]`));
+            } else {
 
+                toHide = toHide.add(forecasts.not('[data-aggregate-id]'));
+                $('#no-forecast-site-selection').attr('hidden', true);
+            }
             // if current forecast selection is invalid, deselect
             if (toHide.filter(':selected').length){
                 forecast_select.val('');
             }
+            toHide.attr('hidden', 'true');
             // if all options are hidden, show "no matching forecasts"
             if (toHide.length == forecasts.length){
                 forecast_select.val('');
-                $('#no-forecasts').removeAttr('hidden');
+                //
+                if ($('#no-forecast-site-selection').attr('hidden') || compareTo == 'aggregate'){
+                    $('#no-forecasts').removeAttr('hidden');
+                }
             } else {
                 $('#no-forecasts').attr('hidden', true);
             }
-            filterObservations();
+            if (compareTo == 'observation'){
+                filterObservations();
+            } else {
+                filterAggregates();
+            }
         }
 
+        function filterAggregates(){
+            /*
+             * Filter aggregate options based on radio buttons
+             */
+            aggregates = aggregateSelector.find('option').slice(2);
+            aggregates.removeAttr('hidden');
+            selectedForecast = $('#forecast-select :selected');
+            if (selectedForecast.length){
+                aggregate_id = selectedForecast.attr('data-aggregate-id');
+                toHide = searchSelect('#aggregate-option-search', '#aggregate-select', 1);
+                toHide = toHide.add(aggregates.not(`[data-aggregate-id=${aggregate_id}]`));
+                if ((toHide.length == aggregates.length) && aggregate_id){
+                    $('#no-aggregates').removeAttr('hidden');
+                } else {
+                    $('#no-aggregates').attr('hidden', true);
+                }
+                $('#no-aggregate-forecast-selection').attr('hidden', true);
+            } else {
+                toHide = aggregates;
+                $('#no-aggregate-forecast-selection').removeAttr('hidden');
+            }
+            toHide.attr('hidden', true);
+        }
 
         function filterObservations(){
             observations = $('#observation-select option').slice(2);
@@ -193,7 +266,7 @@ $(document).ready(function() {
                 // retrieve the current site id and variable from the selected forecast
                 site_id = selectedForecast.attr('data-site-id');
                 variable = selectedForecast.attr('data-variable');
-                $('#no-forecast-selection').attr('hidden', true);
+                $('#no-observation-forecast-selection').attr('hidden', true);
 
                 // Build the list of optiosn to hide by creating a set from
                 // the lists of elements to hide from search, site id and variable
@@ -212,40 +285,60 @@ $(document).ready(function() {
                 }
             } else {
                 observations.attr('hidden', true);
-                $('#no-forecast-selection').removeAttr('hidden');
+                $('#no-observation-forecast-selection').removeAttr('hidden');
             }
         }
 
         // Declare handles to each field's input widgets, and insert a variable select
         // widget for Forecast filtering.
         var widgetContainer = $('<div class="pair-selector-wrapper collapse"></div>');
+        var aggregateSelector = newSelector("aggregate", "forecast");
         var siteSelector = newSelector("site");
         var obsSelector = newSelector("observation", "forecast");
         var fxSelector = newSelector("forecast", "site");
         var fxVariableSelector = createVariableSelect();
         fxSelector.find('.report-field-filters').append(fxVariableSelector);
-        var addButton = $('<a role="button" class="btn btn-primary" id="add-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
+        var addObsButton = $('<a role="button" class="btn btn-primary" id="add-obs-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
+        var addAggButton = $('<a role="button" class="btn btn-primary" id="add-agg-object-pair" style="padding-left: 1em">Add a Forecast, aggregate pair</a>');
+
+
+        // Radio button for selecting between an aggregate or site
+        var obsAggRadio = $(`<div><b>Compare Forecast to&colon;</b>
+                             <input type="radio" name="observation-aggregate-radio" value="observation" checked> Observation
+                             <input type="radio" name="observation-aggregate-radio" value="aggregate">Aggregate<br/></div>`);
+        widgetContainer.append(obsAggRadio);
+        radio_inputs = obsAggRadio.find('input[type=radio]');
+        radio_inputs.change(determineWidgets);
 
         // Add the elements to the widget Container, so that the single container may
         // be inserted into the DOM
         widgetContainer.append(siteSelector);
         widgetContainer.append(fxSelector);
         widgetContainer.append(obsSelector);
-        widgetContainer.append(addButton);
+        widgetContainer.append(aggregateSelector);
+        widgetContainer.append(addObsButton);
+        widgetContainer.append(addAggButton);
+
+        // hide aggregate controls by default
+        addAggButton.attr('hidden', true);
+        aggregateSelector.attr('hidden', true);
 
         // Register callback functions
         siteSelector.find('#site-option-search').keyup(filterSites);
         obsSelector.find('#observation-option-search').keyup(filterObservations);
         fxSelector.find('#forecast-option-search').keyup(filterForecasts);
+        aggregateSelector.find('#aggregate-option-search').keyup(filterAggregates);
 
         // create variables pointing to the specific select elements
         var observation_select = obsSelector.find('#observation-select');
         var forecast_select = fxSelector.find('#forecast-select');
         var site_select = siteSelector.find('#site-select');
+        var aggregate_select = aggregateSelector.find('#aggregate-select');
         
         site_select.change(filterForecasts);
         variable_select.change(filterForecasts);
         forecast_select.change(filterObservations);
+        forecast_select.change(filterAggregates);
 
         // insert options from page_data into the select elements
         $.each(page_data['sites'], function(){
@@ -271,10 +364,20 @@ $(document).ready(function() {
                     .val(this.forecast_id)
                     .attr('hidden', true)
                     .attr('data-site-id', this.site_id)
+                    .attr('data-aggregate-id', this.aggregate_id)
+                    .attr('data-variable', this.variable));
+        });
+        $.each(page_data['aggregates'], function(){
+            aggregate_select.append(
+                $('<option></option>')
+                    .html(this.name)
+                    .val(this.aggregate_id)
+                    .attr('hidden', true)
+                    .attr('data-aggregate-id', this.aggregate_id)
                     .attr('data-variable', this.variable));
         });
         
-        addButton.click(function(){
+        addObsButton.click(function(){
             /*
              * 'Add a Forecast, Observation pair button on button click
              *
@@ -285,7 +388,8 @@ $(document).ready(function() {
                 // If both inputs contain valid data, create a pair and add it to the DOM
                 var selected_observation = observation_select.find('option:selected')[0];
                 var selected_forecast = forecast_select.find('option:selected')[0];
-                pair = addPair(selected_observation.text,
+                pair = addPair('observation',
+                               selected_observation.text,
                                selected_observation.value,
                                selected_forecast.text,
                                selected_forecast.value);
@@ -305,6 +409,34 @@ $(document).ready(function() {
                 }
             }
         });
+        addAggButton.click(function(){
+            /*
+             * Add a forecast, aggregate pair
+             */
+            if (aggregate_select.val() && forecast_select.val()){
+                var selected_aggregate = aggregate_select.find('option:selected')[0];
+                var selected_forecast = forecast_select.find('option:selected')[0];
+                pair = addPair('aggregate',
+                               selected_aggregate.text,
+                               selected_aggregate.value,
+                               selected_forecast.text,
+                               selected_forecast.value);
+                pair_container.append(pair);
+                pair_index++;
+                $(".empty-reports-list")[0].hidden = true;
+                forecast_select.css('border', '');
+                observation_select.css('border', '');
+            } else {
+                // Otherwise apply a red border to alert the user to need of input
+                if (forecast_select.val() == null){
+                    forecast_select.css('border', '2px solid #F99');
+                }
+                if (observation_select.val() == null){
+                    observation_select.css('border', '2px solid #F99');
+                }
+            }
+
+        });
         return widgetContainer;
     }
     /*
@@ -319,7 +451,7 @@ $(document).ready(function() {
     pair_index = 0;
     // call the function to initialize the pair creation widget and insert it into the DOM
     pair_selector = createPairSelector();
-    pair_control_container.append($('<a role="button" class="full-width object-pair-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Observation pairs</a>'));
+    pair_control_container.append($('<a role="button" class="full-width object-pair-button collapsed" data-toggle="collapse" data-target=".pair-selector-wrapper">Create Forecast Evaluation pairs</a>'));
     pair_control_container.append(pair_selector);
     registerDatetimeValidator('period-start');
     registerDatetimeValidator('period-end')

--- a/sfa_dash/templates/data/report.html
+++ b/sfa_dash/templates/data/report.html
@@ -1,4 +1,5 @@
 {% extends "dash/data.html" %}
 {% block content %}
+{% include 'sections/notifications.html' %}
 {{ report | safe }}
 {% endblock %}

--- a/sfa_dash/templates/forms/deletion_form.html
+++ b/sfa_dash/templates/forms/deletion_form.html
@@ -4,12 +4,12 @@
 {% if metadata is defined %}
 {% set page_title = 'Delete ' + data_type %}
 {{ metadata | safe }}
-{% include "sections/notifications.html" %}
+{% endif %}
+{% include 'sections/notifications.html' %}
 <form action="{{ url_for('data_dashboard.delete_'+data_type, uuid=uuid) }}" method="post" id="delete-form", enctype='application/json'>
   <p>Are you sure you want to delete this resource? This action is irreversible.</p>
   <button type="submit" form="delete-form" value="Submit" class="btn btn-danger btn-sml">Yes</button>
   <a href="{{ url_for('data_dashboard.' + data_type + '_view', uuid=uuid) }}" class="btn btn-primary">No</a>
   {{ form.token() }}
 </form>
-{% endif %}
 {% endblock %}

--- a/sfa_dash/templates/forms/deletion_form.html
+++ b/sfa_dash/templates/forms/deletion_form.html
@@ -6,10 +6,13 @@
 {{ metadata | safe }}
 {% endif %}
 {% include 'sections/notifications.html' %}
+{% if data_type and uuid %}
+{# setting data_type and uuid prints deletion links #}
 <form action="{{ url_for('data_dashboard.delete_'+data_type, uuid=uuid) }}" method="post" id="delete-form", enctype='application/json'>
   <p>Are you sure you want to delete this resource? This action is irreversible.</p>
   <button type="submit" form="delete-form" value="Submit" class="btn btn-danger btn-sml">Yes</button>
   <a href="{{ url_for('data_dashboard.' + data_type + '_view', uuid=uuid) }}" class="btn btn-primary">No</a>
   {{ form.token() }}
 </form>
+{% endif %}
 {% endblock %}

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -36,7 +36,7 @@
 
      <h5>Observation, Forecast pairs</h5>
 	 <div class="form-element full-width border" style="border-radius:10px;margin:.5em 1em;">
-       <div class="form-element">Forecasts</div><div class="form-element">Observations/aggregates</div>
+       <div class="form-element">Forecasts</div><div class="form-element">Observations/Aggregates</div>
        <div class="object-pair-list">
          <div class="empty-reports-list alert alert-warning">No Pairs Selected</div>
        </div>

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -9,7 +9,8 @@
   <div class="form-group">
       {% if form_data is not defined %} {% set form_data = {} %}{% endif %}
      <div class="form-element full-width">
-       {{ form.input('Name', 'text', 'name', 'Name of the Report.', form_data=form_data) }}
+       {{ form.input('Name', 'text', 'name', 'Name of the Report.',
+                     required=True, form_data=form_data) }}
      </div>
 	 <div class="form-element">
        <label for="start">Start (UTC):</label><br/>

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -36,7 +36,7 @@
 
      <h5>Observation, Forecast pairs</h5>
 	 <div class="form-element full-width border" style="border-radius:10px;margin:.5em 1em;">
-       <div class="form-element">Forecasts</div><div class="form-element">Observations</div>
+       <div class="form-element">Forecasts</div><div class="form-element">Observations/aggregates</div>
        <div class="object-pair-list">
          <div class="empty-reports-list alert alert-warning">No Pairs Selected</div>
        </div>


### PR DESCRIPTION
Adds a radio button that allows switching from picking observation-forecast pairs to aggregate-forecast pairs. Currently updated to parse metadata into the format proposed in https://github.com/SolarArbiter/solarforecastarbiter-core/pull/256: 
`[{'forecast': <forecast_id>,
   'observation': <observation_id>}]`

Screenshots of both states of the new interface below.
![Screenshot from 2019-11-20 10-50-22](https://user-images.githubusercontent.com/21206164/69264007-af6d0400-0b83-11ea-8aab-2e659d06e6be.png)
![Screenshot from 2019-11-20 10-50-30](https://user-images.githubusercontent.com/21206164/69264010-b09e3100-0b83-11ea-9753-061b9ed4e50c.png)
This PR should wait for the core PR and ensure it works correctly before being merged.