### PR TITLE
Add metrics/categories to report forms

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -69,13 +69,6 @@ class ReportForm(BaseView):
                  for i, f in enumerate(fx)]
         return pairs
 
-    def parse_metrics(self, form_data):
-        """Collect the keys (name attributes) of the form elements with a value
-        attribute of metrics. These elements are checkbox inputs, and are only
-        included in the form data when selected.
-        """
-        return [k.lower() for k, v in form_data.items() if v == 'metrics']
-
     def parse_filters(self, form_data):
         """Return an empty array until we know more about how we want
         to configure these filters
@@ -85,7 +78,8 @@ class ReportForm(BaseView):
     def parse_report_parameters(self, form_data):
         params = {}
         params['object_pairs'] = self.zip_object_pairs(form_data)
-        params['metrics'] = self.parse_metrics(form_data)
+        params['metrics'] = request.form.getlist('metrics')
+        params['categories'] = request.form.getlist('categories')
         # filters do not currently work in API
         # params['filters'] = self.parse_filters(form_data)
         params['start'] = form_data['period-start']

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -101,19 +101,18 @@ class ReportForm(BaseView):
                 'error': [('Must include at least 1 Forecast, Observation '
                            'pair.')],
             }
-            return super().get(form_data=form_data, errors=errors)
+            return super().get(form_data=api_payload, errors=errors)
         try:
             reports.post_metadata(api_payload)
         except HTTPError as e:
             if e.response.status_code == 400:
                 # flatten error response to handle nesting
                 errors = e.response.json()['errors']
-                return super().get(form_data=form_data, errors=errors)
             elif e.response.status_code == 404:
                 errors = {'error': ['Permission to create report denied.']}
             else:
                 errors = {'error': ['An unrecoverable error occured.']}
-            return super().get(form_data=form_data, errors=errors)
+            return super().get(form_data=api_payload, errors=errors)
         return redirect(url_for(
             'data_dashboard.reports',
             messages={'creation': 'successful'}))

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -203,6 +203,7 @@ a.object-pair-delete-button{
 }
 .form-element{
   display: inline-block;
+  vertical-align: top;
   box-sizing: border-box;
   padding: .5em 1em;
   position: relative;

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -6,8 +6,9 @@ import pytz
 
 import sfa_dash
 from sfa_dash import filters
-from solarforecastarbiter.datamodel import ALLOWED_CATEGORIES
-from solarforecastarbiter.metrics.deterministic import _MAP
+from solarforecastarbiter.datamodel import (
+    ALLOWED_CATEGORIES, ALLOWED_DETERMINISTIC_METRICS)
+
 
 TIMEZONES = pytz.country_timezones('US') + list(
     filter(lambda x: 'GMT' in x, pytz.all_timezones))
@@ -18,7 +19,7 @@ VARIABLE_OPTIONS = {key: f'{value} ({filters.api_varname_to_units(key)})'
 
 TIMEZONE_OPTIONS = {tz: tz.replace('_', ' ') for tz in TIMEZONES}
 
-DETERMINISTIC_METRICS = list(_MAP.keys())
+DETERMINISTIC_METRICS = ALLOWED_DETERMINISTIC_METRICS.keys()
 
 
 def template_variables():

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -17,9 +17,8 @@ TIMEZONES = pytz.country_timezones('US') + list(
 VARIABLE_OPTIONS = {key: f'{value} ({filters.api_varname_to_units(key)})'
                     for key, value in filters.variable_mapping.items()}
 
-TIMEZONE_OPTIONS = {tz: tz.replace('_', ' ') for tz in TIMEZONES}
 
-DETERMINISTIC_METRICS = ALLOWED_DETERMINISTIC_METRICS.keys()
+TIMEZONE_OPTIONS = {tz: tz.replace('_', ' ') for tz in TIMEZONES}
 
 
 def template_variables():
@@ -28,5 +27,5 @@ def template_variables():
         'variable_options': VARIABLE_OPTIONS,
         'timezone_options': TIMEZONE_OPTIONS,
         'metric_categories': ALLOWED_CATEGORIES,
-        'deterministic_metrics': DETERMINISTIC_METRICS,
+        'deterministic_metrics': ALLOWED_DETERMINISTIC_METRICS,
     }

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -6,6 +6,8 @@ import pytz
 
 import sfa_dash
 from sfa_dash import filters
+from solarforecastarbiter.metrics.calculator import AVAILABLE_CATEGORIES
+from solarforecastarbiter.metrics.deterministic import _MAP
 
 TIMEZONES = pytz.country_timezones('US') + list(
     filter(lambda x: 'GMT' in x, pytz.all_timezones))
@@ -16,10 +18,14 @@ VARIABLE_OPTIONS = {key: f'{value} ({filters.api_varname_to_units(key)})'
 
 TIMEZONE_OPTIONS = {tz: tz.replace('_', ' ') for tz in TIMEZONES}
 
+DETERMINISTIC_METRICS = list(_MAP.keys())
+
 
 def template_variables():
     return {
         'dashboard_version': sfa_dash.__version__,
         'variable_options': VARIABLE_OPTIONS,
         'timezone_options': TIMEZONE_OPTIONS,
+        'metric_categories': AVAILABLE_CATEGORIES,
+        'deterministic_metrics': DETERMINISTIC_METRICS,
     }

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -21,6 +21,9 @@ VARIABLE_OPTIONS = {key: f'{value} ({filters.api_varname_to_units(key)})'
 TIMEZONE_OPTIONS = {tz: tz.replace('_', ' ') for tz in TIMEZONES}
 
 
+DEFAULT_METRICS = ['mae', 'mbe', 'rmse']
+
+
 def template_variables():
     return {
         'dashboard_version': sfa_dash.__version__,
@@ -28,4 +31,5 @@ def template_variables():
         'timezone_options': TIMEZONE_OPTIONS,
         'metric_categories': ALLOWED_CATEGORIES,
         'deterministic_metrics': ALLOWED_DETERMINISTIC_METRICS,
+        'default_metrics': DEFAULT_METRICS,
     }

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -6,7 +6,7 @@ import pytz
 
 import sfa_dash
 from sfa_dash import filters
-from solarforecastarbiter.metrics.calculator import AVAILABLE_CATEGORIES
+from solarforecastarbiter.datamodel import ALLOWED_CATEGORIES
 from solarforecastarbiter.metrics.deterministic import _MAP
 
 TIMEZONES = pytz.country_timezones('US') + list(
@@ -26,6 +26,6 @@ def template_variables():
         'dashboard_version': sfa_dash.__version__,
         'variable_options': VARIABLE_OPTIONS,
         'timezone_options': TIMEZONE_OPTIONS,
-        'metric_categories': AVAILABLE_CATEGORIES,
+        'metric_categories': ALLOWED_CATEGORIES,
         'deterministic_metrics': DETERMINISTIC_METRICS,
     }

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -78,10 +78,16 @@
      #}
      <div class="form-element">
      <label>Metrics</label><br>
-       <input type="checkbox" name="MAE" value="metrics">MAE<br>
-       <input type="checkbox" name="RMSE" value="metrics">RMSE<br>
-       <input type="checkbox" name="MBE" value="metrics">MBE<br>
-       {#<input type="checkbox" name="metrics" value="Skill over">Skill over <input type='text' class="form-control" style="width:inherit"/><br>#}
+       {% for metric in deterministic_metrics %}
+       <input type="checkbox" name="metrics" value="{{ metric }}">
+       <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ metric }}</a><br/>
+       {% endfor %}
+     </div>
+     <div class="form-element">
+     <label>Categories</label></br>
+     {% for category in metric_categories %}
+     <input type="checkbox" name="categories" value="{{ category }}"> {{ category }}<br/>
+     {% endfor %}
      </div>
     {{ form.token() }}
   </div>

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -15,7 +15,7 @@
 	 <div class="form-element">
        <label for="start">Start (UTC):</label><br/>
        <div class="input-wrapper">
-         <input type="text" name="period-start" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data is defined %}value="{{form_data['period-start']}}"{% endif %}></input>
+         <input type="text" name="period-start" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data %}value="{{form_data['report_parameters']['start']}}"{% endif %}></input>
        </div>
        {{ form.help_button('period-start') }}
        <span class="period-start-help-text form-text text-muted help-text collapse" aria-hidden>
@@ -25,7 +25,7 @@
      <div class="form-element">
        <label for="end">End (UTC)</label><br/>
        <div class="input-wrapper">
-         <input type="text" name="period-end" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data is defined %}value="{{form_data['period-end']}}"{% endif %}></input>
+         <input type="text" name="period-end" class="form-control" placeholder="YYYY-MM-DDTHH:MMZ" required {% if form_data %}value="{{form_data['report_parameters']['end']}}"{% endif %}></input>
        </div>
        {{ form.help_button('period-end') }}
        <span class="period-end-help-text form-text text-muted help-text collapse" aria-hidden>
@@ -79,14 +79,14 @@
      <div class="form-element">
      <label>Metrics</label><br>
        {% for metric, label in deterministic_metrics.items() %}
-       <input type="checkbox" name="metrics" value="{{ metric }}">
+       <input type="checkbox" name="metrics" value="{{ metric }}" {% if form_data and metric in form_data['report_parameters']['metrics'] %}checked{% endif %}>
        <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ label }}</a><br/>
        {% endfor %}
      </div>
      <div class="form-element">
      <label>Categories</label></br>
      {% for category, label in metric_categories.items() %}
-     <input type="checkbox" name="categories" value="{{ category }}"> {{ label }}<br/>
+     <input type="checkbox" name="categories" value="{{ category }}" {% if form_data and category in form_data['report_parameters']['categories'] %}checked{% endif %}> {{ label }}<br/>
      {% endfor %}
      </div>
     {{ form.token() }}

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -78,9 +78,9 @@
      #}
      <div class="form-element">
      <label>Metrics</label><br>
-       {% for metric in deterministic_metrics %}
+       {% for metric, label in deterministic_metrics.items() %}
        <input type="checkbox" name="metrics" value="{{ metric }}">
-       <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ metric }}</a><br/>
+       <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ label }}</a><br/>
        {% endfor %}
      </div>
      <div class="form-element">

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -79,8 +79,10 @@
      <div class="form-element">
      <label>Metrics</label><br>
        {% for metric, label in deterministic_metrics.items() %}
+       {% if metric != 's' %}
        <input type="checkbox" name="metrics" value="{{ metric }}" {% if form_data and metric in form_data['report_parameters']['metrics'] %}checked{% endif %}>
        <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ label }}</a><br/>
+       {% endif %}
        {% endfor %}
      </div>
      <div class="form-element">

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -80,7 +80,7 @@
      <label>Metrics</label><br>
        {% for metric, label in deterministic_metrics.items() %}
        {% if metric != 's' %}
-       <input type="checkbox" name="metrics" value="{{ metric }}" {% if form_data and metric in form_data['report_parameters']['metrics'] %}checked{% endif %}>
+       <input type="checkbox" name="metrics" value="{{ metric }}" {% if form_data %}{% if metric in form_data['report_parameters']['metrics'] %}checked{% endif %}{% elif metric in default_metrics  %}checked{% endif %}>
        <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ label }}</a><br/>
        {% endif %}
        {% endfor %}
@@ -88,7 +88,7 @@
      <div class="form-element">
      <label>Categories</label></br>
      {% for category, label in metric_categories.items() %}
-     <input type="checkbox" name="categories" value="{{ category }}" {% if form_data and category in form_data['report_parameters']['categories'] %}checked{% endif %}> {{ label }}<br/>
+     <input type="checkbox" name="categories" value="{{ category }}" {% if form_data %}{% if category in form_data['report_parameters']['categories'] %}checked{% endif %}{% else %}checked{% endif %}> {{ label }}<br/>
      {% endfor %}
      </div>
     {{ form.token() }}

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -85,8 +85,8 @@
      </div>
      <div class="form-element">
      <label>Categories</label></br>
-     {% for category in metric_categories %}
-     <input type="checkbox" name="categories" value="{{ category }}"> {{ category }}<br/>
+     {% for category, label in metric_categories.items() %}
+     <input type="checkbox" name="categories" value="{{ category }}"> {{ label }}<br/>
      {% endfor %}
      </div>
     {{ form.token() }}

--- a/test_api/docker-compose.yml
+++ b/test_api/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - mysql
     volumes:
       - ./solarforecastarbiter-api/datastore/migrations:/migrations
-    entrypoint: sh ./wait-for -t 60 mysql:3306 -- /migrate -path=/migrations/ -database mysql://root:testpassword@tcp(mysql:3306)/arbiter_data goto 29
+    entrypoint: sh ./wait-for -t 60 mysql:3306 -- /migrate -path=/migrations/ -database mysql://root:testpassword@tcp(mysql:3306)/arbiter_data goto 39
 
   api:
     build: .


### PR DESCRIPTION
Depends on https://github.com/SolarArbiter/solarforecastarbiter-core/pull/224

This PR will introduce metrics and categories( formerly referred to as subdivision in draft versions?) into reports selection. Currently in draft state and drawing from the metrics modules to populate options. 

Very basic widgets look as follows: 
![Screenshot from 2019-11-25 15-37-21](https://user-images.githubusercontent.com/21206164/69584058-855b7d80-0f99-11ea-8271-1355d9134645.png)

@wholmgren Is the default behavior to compute all permutations of the selected metric and category for each object pair?