### PR TITLE
fix report head spacing, give extra parameters text area a name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,6 +47,9 @@ jobs:
 
     - script: pip install .
       displayName: 'Install sfa_dash'
+    
+    - script: docker wait solararbitersolarforecastarbiter_dashboard_mysql_1
+      displayName: 'Wait for MySQL'
 
     - script: pytest sfa_dash
       displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -48,7 +48,7 @@ jobs:
     - script: pip install .
       displayName: 'Install sfa_dash'
     
-    - script: docker wait solararbitersolarforecastarbiter_dashboard_mysql_1
+    - script: docker wait solararbitersolarforecastarbiter_dashboard_migrate_schemas_1
       displayName: 'Wait for MySQL'
 
     - script: pytest sfa_dash

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -44,6 +44,7 @@ class BaseView(MethodView):
             else:
                 self.temp_args.update({
                     'plot': script_plot[1],
+                    'includes_bokeh': True,
                     'bokeh_script': script_plot[0]
                 })
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -128,7 +128,7 @@ class ReportView(BaseView):
     def template_args(self):
         report_template = report_to_html_body(self.metadata)
         return {'report': report_template,
-                'bokeh_script': True}
+                'includes_bokeh': True}
 
     def get(self, uuid):
         try:

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -50,7 +50,9 @@
 <div class="row data-plots-wrapper">
 {{ plot | safe }}
 </div>
+{% if bokeh_script is defined %}
 {{ bokeh_script | safe }}
+{% endif %}
 <script src="/static/js/plot-bound-parsing.js"></script>
 <div class="form-group mt-3">
 <div class="form-element">

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -50,6 +50,7 @@
 <div class="row data-plots-wrapper">
 {{ plot | safe }}
 </div>
+{{ bokeh_script | safe }}
 <script src="/static/js/plot-bound-parsing.js"></script>
 <div class="form-group mt-3">
 <div class="form-element">

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -15,6 +15,9 @@
 <div class="row data-plots-wrapper">
 {{ plot | safe }}
 </div>
+{% if bokeh_script is defined %}
+{{ bokeh_script | safe }}
+{% endif %}
 <script src="/static/js/plot-bound-parsing.js"></script>
 <div class="form-group mt-3">
 <div class="form-element">

--- a/sfa_dash/templates/forms/form_macros.jinja
+++ b/sfa_dash/templates/forms/form_macros.jinja
@@ -95,6 +95,6 @@ UTC
 {% macro extra_parameters() %}
 <div class="form-element full-width">                                           
 <label>Extra parameters (optional)</label>                                    
-<textarea cols="40" rows="5" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
+<textarea cols="40" rows="5" name="extra_parameters" class="form-control extra-parameters-field" placeholder="This field will store any ASCII text. We recommend using it to store other parameters you have collected in a format such as YAML or JSON."></textarea>
 </div>
 {% endmacro %}

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -15,8 +15,7 @@
 
 <!-- Custom styles for this template -->
 <link href="/static/css/styles.css" type="text/css" rel="stylesheet">
-{% if bokeh_script is defined %}
-{# if a script is provided, load bokeh.js #}
+{% if includes_bokeh %}
 <link
     href="https://cdn.pydata.org/bokeh/release/bokeh-1.2.0.min.css"
     rel="stylesheet" type="text/css">
@@ -29,7 +28,6 @@
 <script src="https://cdn.pydata.org/bokeh/release/bokeh-1.2.0.min.js"></script>
 <script src="https://cdn.pydata.org/bokeh/release/bokeh-widgets-1.2.0.min.js"></script>
 <script src="https://cdn.pydata.org/bokeh/release/bokeh-tables-1.2.0.min.js"></script>
-{{ bokeh_script | safe }}
 {% endif %}
 
 <script src="/static/js/table-search.js"></script>


### PR DESCRIPTION
closes #183 
This was a maddening and bizarre issue. Also fixes a problem introduced in #167, wherein I created a macro for the `extra_parameter` fields but omitted a name, causing a bad request key error on form submission.