### PR TITLE
add beta4 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
   while processing the report.
 
 - The dashboard report view now allows users to search metric plots by
-  forecast ant to sort metric plots by metric, category and forecast.
+  forecast and to sort metric plots by metric, category and forecast.
 
 - Dashboard users can now download report metrics as a csv.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
 - Reports now contain a table of all included metrics over the entire selected
   period.
 
-- Reports may be configured to filtered data by quality flag. Currently allows
+- Reports may be configured to filter data by quality flag. Currently allows
   filtering of *user flagged* and *nighttime* values.
 
 - The dashboard report view now allows users to search metric plots by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ in this file.
 Detailed changes to the Solar Forecast Arbiter Core python library can be found
 in the core documentation's [what's new](https://solarforecastarbiter-core.readthedocs.io/en/latest/whatsnew/index.html) series.
 
+## [1.0beta4] - Unreleased
+
+### Added
+
+- Support for quality flag filtering of report values. Currently allows removal
+  of *user flagged* and *nighttime* values.
+
+- Reports now contain a summary of data affected by the data resampling and
+  alignment process. The summary includes the number of data points removed by
+  each phase of validation.
+
+- Reports now contain a table of all included metrics over the entire selected
+  period.
+
+- Reports in the *pending* and *failed* state now display a message to the user
+  about their status. For failed reports, this is a list of errors encountered
+  while processing the report.
+
+- The dashboard report view now allows for searching metric plots by forecast
+  as well as sorting metric plots by metric, category and forecast.
+
+- The dashboard now allows for report metrics to be downloaded as a csv.
+
+
+### Changed
+
+- The API's report response's `raw_report` attribute has updated to reflect the
+  set of processed report data needed for rendering a final report. The
+  `raw_report` attribute was previously presented as a serialized version of
+  the final rendered report.
+
+- Major refactoring of the core library's Report object. See the core
+  [what's new](https://solarforecastarbiter-core.readthedocs.io/en/latest/whatsnew/1.0.0b4.html)
+  for details.
+
 ## [1.0beta3] - 2019-12-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
 
 ### Added
 
-- Support for quality flag filtering of report values. Currently allows removal
-  of *user flagged* and *nighttime* values.
+- Report data may now be filtered by quality flag. Currently allows
+  filtering of *user flagged* and *nighttime* values.
 
 - Reports now contain a summary of data affected by the data resampling and
   alignment process. The summary includes the number of data points removed by
@@ -24,20 +24,19 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
   about their status. For failed reports, this is a list of errors encountered
   while processing the report.
 
-- The dashboard report view now allows for searching metric plots by forecast
-  as well as sorting metric plots by metric, category and forecast.
+- The dashboard report view now allows users to search metric plots by
+  forecast ant to sort metric plots by metric, category and forecast.
 
-- The dashboard now allows for report metrics to be downloaded as a csv.
-
+- Dashboard users can now download report metrics as a csv.
 
 ### Changed
 
-- The API's report response's `raw_report` attribute has updated to reflect the
+- The API's report response's `raw_report` attribute was updated to reflect the
   set of processed report data needed for rendering a final report. The
   `raw_report` attribute was previously presented as a serialized version of
   the final rendered report.
 
-- Major refactoring of the core library's Report object. See the core
+- The core library's Report received a major refactoring. See the core
   [what's new](https://solarforecastarbiter-core.readthedocs.io/en/latest/whatsnew/1.0.0b4.html)
   for details.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,11 @@ in this file.
 Detailed changes to the Solar Forecast Arbiter Core python library can be found
 in the core documentation's [what's new](https://solarforecastarbiter-core.readthedocs.io/en/latest/whatsnew/index.html) series.
 
-## [1.0beta4] - Unreleased
+## [1.0beta4] - 2020-02-07
 
 ### Added
 
-- Report data may now be filtered by quality flag. Currently allows
-  filtering of *user flagged* and *nighttime* values.
+- Daily updating precomputed reports for select reference data.
 
 - Reports now contain a summary of data affected by the data resampling and
   alignment process. The summary includes the number of data points removed by
@@ -20,15 +19,19 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
 - Reports now contain a table of all included metrics over the entire selected
   period.
 
-- Reports in the *pending* and *failed* state now display a message to the user
-  about their status. For failed reports, this is a list of errors encountered
-  while processing the report.
+- Reports may be configured to filtered data by quality flag. Currently allows
+  filtering of *user flagged* and *nighttime* values.
 
 - The dashboard report view now allows users to search metric plots by
   forecast and to sort metric plots by metric, category and forecast.
 
-- Dashboard users can now download report metrics as a csv.
-- Daily updating precomputed reports for select reference data.
+- Dashboard users can now download report metrics as a csv using a link in the
+  *Metrics* section of the report.
+
+- Reports in the *pending* and *failed* state now display a message to the user
+  about their status. For failed reports, this is a list of errors encountered
+  while processing the report.
+
 ### Changed
 
 - The API's report response's `raw_report` attribute was updated to reflect the
@@ -39,6 +42,23 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
 - The core library's Report received a major refactoring. See the core
   [what's new](https://solarforecastarbiter-core.readthedocs.io/en/latest/whatsnew/1.0.0b4.html)
   for details.
+
+- The button for downloading timeseries data from the dashboard has moved to
+  below the plots on any Forecast, Observation or Probabilistic Forecast's
+  page. The same start and end times are used for downloading data and creating
+  plots.
+
+- The start and end time values for the dashboard's timeseries plots are now
+  prefilled with time range requested. By default, this will display the last
+  three days of data.
+
+### Fixed
+
+- Corrected handling of empty observation timeseries during metrics
+  preprocessing which was causing report processing to fail.
+
+- Corrected handling of `interval_label` == `ending` when computing metrics
+  for a report containing mixed `interval_label`s.
 
 ## [1.0beta3] - 2019-12-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ in the core documentation's [what's new](https://solarforecastarbiter-core.readt
   forecast and to sort metric plots by metric, category and forecast.
 
 - Dashboard users can now download report metrics as a csv.
-
+- Daily updating precomputed reports for select reference data.
 ### Changed
 
 - The API's report response's `raw_report` attribute was updated to reflect the


### PR DESCRIPTION
Adds changelog documentation for beta 4. This may be incomplete and should probably stay open until just before tagging.