### PR TITLE
hide metric toc 

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -159,6 +159,7 @@ class ReportView(BaseView):
         report_kwargs.update({
             'report_template': report_template,
             'dash_url': request.url_root.rstrip('/'),
+            'include_metrics_toc': False,
             'includes_bokeh': True
         })
         if not include_timeseries:

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -410,6 +410,14 @@ th.selection-column{
 
 /* report stuff */
 
+#report-block h1:before, #report-block h2:before, #report-block h3:before{
+   display: block;
+   content: "";
+   margin-top: -160px;
+   height: 160px;
+   visibility: hidden;
+
+}
 #report-block h1, #report-block h2, #report-block h3{
     margin-top: 2rem;
     margin-bottom: .5rem;

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -416,7 +416,6 @@ th.selection-column{
    margin-top: -160px;
    height: 160px;
    visibility: hidden;
-
 }
 #report-block h1, #report-block h2, #report-block h3{
     margin-top: 2rem;

--- a/sfa_dash/templates/dash/data.html
+++ b/sfa_dash/templates/dash/data.html
@@ -1,13 +1,11 @@
 {% extends "base.html" %}
 {% block dash %}
 <!-- org name -->
+{% if page_title is defined or breadcrumb is defined %}
 <h2 class="page-title">
-{% if page_title is defined %}
-{{ page_title }}
-{%  else %}
-{{ breadcrumb|safe }}
-{% endif %}
+{{ page_title }}{{ breadcrumb|safe }}
 </h2>
+{% endif %}
 {% include "dash/subnav.html" %}
 {% block content %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
Removes the metric table of contents for dashboard reports, add space to report headers so links don't move past them.

Supports https://github.com/SolarArbiter/solarforecastarbiter-core/pull/332