### PR TITLE
add format examples link

### DIFF
--- a/sfa_dash/templates/data/time_widgets.html
+++ b/sfa_dash/templates/data/time_widgets.html
@@ -19,7 +19,7 @@
   <label for="format">Format: </label>
   <input type="radio" name="format" value="text/csv" checked>CSV</input>
   <input type="radio" name="format" value="application/json">JSON</input>
-  (<a href="https://solarforecastarbiter.org/datamodel/#downloads" target="_blank">format examples</a>)
+  &lpar;<a href="https://solarforecastarbiter.org/datamodel/#downloads" target="_blank">format examples</a>&rpar;
   <input type="text" class="start" name="start" hidden>
   <input type="text" class="end" name="end" hidden>
   {{ form.token() }}

--- a/sfa_dash/templates/data/time_widgets.html
+++ b/sfa_dash/templates/data/time_widgets.html
@@ -16,9 +16,10 @@
   <button type="submit" form="plot-range-adjust" value="Submit" class="btn btn-primary">Set time range</button>
   <form action="" method="post" id="download-form" onsubmit="ParseStartEnd()">
   <button type="submit" form="download-form" value="Submit" class="btn btn-primary">Download data</button>
-  <label for="format">Format:</label>
-  <input type="radio" name="format" value="text/csv" checked>CSV</input><a href="https://solarforecastarbiter.org/datamodel/#csv" target="_blank">&#x1f6c8;</a>
-  <input type="radio" name="format" value="application/json">JSON</input><a href="https://solarforecastarbiter.org/datamodel/#json" target="_blank">&#x1f6c8;</a>
+  <label for="format">Format: </label>
+  <input type="radio" name="format" value="text/csv" checked>CSV</input>
+  <input type="radio" name="format" value="application/json">JSON</input>
+  (<a href="https://solarforecastarbiter.org/datamodel/#downloads" target="_blank">format examples</a>)
   <input type="text" class="start" name="start" hidden>
   <input type="text" class="end" name="end" hidden>
   {{ form.token() }}


### PR DESCRIPTION
I tried turning the "Format:" label into a link, but it felt awkward and inconsistent. This is simple and explicit: 
![Screenshot from 2020-02-11 12-19-04](https://user-images.githubusercontent.com/21206164/74270623-c32e8f00-4cc8-11ea-9478-2bd126059cda.png)
