### PR TITLE
Simplify use of handle_response

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pymysql
 python-jose
 blinker
 cryptography
-bokeh
+bokeh==1.4.0
 git+git://github.com/solararbiter/solarforecastarbiter-core#egg=solarforecastarbiter [all]
 tables==3.5.1
 prometheus_flask_exporter

--- a/sfa_dash/api_interface/__init__.py
+++ b/sfa_dash/api_interface/__init__.py
@@ -4,6 +4,7 @@ from flask import current_app as app
 
 
 from sfa_dash import oauth_request_session
+from sfa_dash.api_interface.util import handle_response
 
 
 def get_request(path, **kwargs):
@@ -21,8 +22,8 @@ def get_request(path, **kwargs):
     """
     # may need to handle errors if oauth_request_session does not exist somehow
     # definitely need to handle errors here
-    return oauth_request_session.get(
-        f'{app.config["SFA_API_URL"]}{path}', **kwargs)
+    return handle_response(oauth_request_session.get(
+        f'{app.config["SFA_API_URL"]}{path}', **kwargs))
 
 
 def post_request(path, payload, json=True):
@@ -49,8 +50,8 @@ def post_request(path, payload, json=True):
     else:
         kwargs = {'headers': {'Content-type': 'text/csv'},
                   'data': payload}
-    return oauth_request_session.post(
-        f'{app.config["SFA_API_URL"]}{path}', **kwargs)
+    return handle_response(oauth_request_session.post(
+        f'{app.config["SFA_API_URL"]}{path}', **kwargs))
 
 
 def delete_request(path, **kwargs):
@@ -66,5 +67,5 @@ def delete_request(path, **kwargs):
     requests.Response
         The api response.
     """
-    return oauth_request_session.delete(
-        f'{app.config["SFA_API_URL"]}{path}', **kwargs)
+    return handle_response(oauth_request_session.delete(
+        f'{app.config["SFA_API_URL"]}{path}', **kwargs))

--- a/sfa_dash/api_interface/tests/test_util.py
+++ b/sfa_dash/api_interface/tests/test_util.py
@@ -2,7 +2,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 
-from sfa_dash.blueprints.util import handle_response
+from sfa_dash.api_interface.util import handle_response
 from sfa_dash.errors import DataRequestException
 
 
@@ -22,7 +22,7 @@ def mock_response(mocker):
 
 @pytest.fixture()
 def mock_request(mocker):
-    mocker.patch('sfa_dash.blueprints.util.request')
+    mocker.patch('sfa_dash.api_interface.util.request')
 
 
 @pytest.mark.parametrize('code', [

--- a/sfa_dash/api_interface/util.py
+++ b/sfa_dash/api_interface/util.py
@@ -1,0 +1,73 @@
+from flask import request
+
+from sfa_dash.errors import DataRequestException
+
+
+# Utility functions pertaining to interactions with the api.
+
+def handle_response(request_object):
+    """Parses the response from a request object. On an a resolvable
+    error, raises a DataRequestException with a default error
+    message.
+
+    Parameters
+    ----------
+    request_object: requests.Response
+        The response object from an executed request.
+
+    Returns
+    -------
+    dict, str or None
+        Note that this function checks the content-type of a response
+        and returns the appropriate type. A Dictionary parsed from a
+        JSON object, or a string. Returns None when a 204 is encountered.
+        Users should be mindful of the expected response body from the
+        API.
+
+    Raises
+    ------
+    sfa_dash.errors.DataRequestException
+        If a recoverable 400 level error has been encountered.
+        The errors attribute will contain a dict of errors.
+    requests.exceptions.HTTPError
+        If the status code received from the API could not be
+        handled.
+    """
+    if not request_object.ok:
+        errors = {}
+        if request_object.status_code == 400:
+            errors = request_object.json()
+        elif request_object.status_code == 401:
+            errors = {
+                '401': "You do not have permission to create this resource."
+            }
+        elif request_object.status_code == 404:
+            previous_page = request.headers.get('Referer', None)
+            errors = {'404': (
+                'The requested object could not be found. You may need to '
+                'request access from the data owner.')
+            }
+            if previous_page is not None and previous_page != request.url:
+                errors['404'] = errors['404'] + (
+                    f' <a href="{previous_page}">Return to the previous '
+                    'page.</a>')
+        elif request_object.status_code == 422:
+            errors = request_object.json()['errors']
+        if errors:
+            raise DataRequestException(request_object.status_code, **errors)
+        else:
+            # Other errors should be due to bugs and not by attempts to reach
+            # inaccessible data. Allow exceptions to be raised
+            # so that they can be reported to Sentry.
+            request_object.raise_for_status()
+    if request_object.request.method == 'GET':
+        # all GET endpoints should return a JSON object
+        if request_object.headers['Content-Type'] == 'application/json':
+            return request_object.json()
+        else:
+            return request_object.text
+    # POST responses should contain a single string uuid of a newly created
+    # object unless a 204 No Content was returned.
+    if request_object.request.method == 'POST':
+        if request_object.status_code != 204:
+            return request_object.text

--- a/sfa_dash/api_interface/util.py
+++ b/sfa_dash/api_interface/util.py
@@ -39,7 +39,7 @@ def handle_response(request_object):
             errors = request_object.json()
         elif request_object.status_code == 401:
             errors = {
-                '401': "You do not have permission to create this resource."
+                '401': "Unauthorized."
             }
         elif request_object.status_code == 404:
             previous_page = request.headers.get('Referer', None)

--- a/sfa_dash/blueprints/aggregates.py
+++ b/sfa_dash/blueprints/aggregates.py
@@ -6,9 +6,8 @@ import pandas as pd
 
 from sfa_dash.api_interface import observations, sites, aggregates
 from sfa_dash.blueprints.base import BaseView
-from sfa_dash.blueprints.util import (filter_form_fields, handle_response,
-                                      parse_timedelta, flatten_dict,
-                                      download_timeseries)
+from sfa_dash.blueprints.util import (filter_form_fields, parse_timedelta,
+                                      flatten_dict, download_timeseries)
 from sfa_dash.errors import DataRequestException
 
 
@@ -21,7 +20,7 @@ class AggregatesView(BaseView):
         return breadcrumb_dict
 
     def template_args(self):
-        aggregates_list = handle_response(aggregates.list_metadata())
+        aggregates_list = aggregates.list_metadata()
         return {
             "breadcrumb": self.breadcrumb_html(self.get_breadcrumb_dict()),
             "aggregates": aggregates_list,
@@ -50,8 +49,7 @@ class AggregateForm(BaseView):
         form_data = request.form
         api_payload = self.aggregate_formatter(form_data)
         try:
-            aggregate_id = handle_response(
-                aggregates.post_metadata(api_payload))
+            aggregate_id = aggregates.post_metadata(api_payload)
         except DataRequestException as e:
             return render_template(
                 self.template, errors=e.errors, form_data=form_data)
@@ -84,8 +82,8 @@ class AggregateObservationAdditionForm(BaseView):
             The metadata of the aggregate used for filtering applicable
             observations.
         """
-        sites_list = handle_response(sites.list_metadata())
-        observations_list = handle_response(observations.list_metadata())
+        sites_list = sites.list_metadata()
+        observations_list = observations.list_metadata()
 
         # Remove observations with greater interval length
         observations_list = list(filter(
@@ -161,8 +159,7 @@ class AggregateObservationAdditionForm(BaseView):
 
     def get(self, uuid, **kwargs):
         try:
-            self.metadata = handle_response(
-                aggregates.get_metadata(uuid))
+            self.metadata = aggregates.get_metadata(uuid)
         except DataRequestException as e:
             return render_template(
                 self.template, errors=e.errors)
@@ -173,8 +170,7 @@ class AggregateObservationAdditionForm(BaseView):
         form_data = request.form
         api_payload = self.aggregate_observation_formatter(form_data)
         try:
-            handle_response(
-                aggregates.update(uuid, api_payload))
+            aggregates.update(uuid, api_payload)
         except DataRequestException as e:
             if 'observations' in e.errors:
                 # unpack list of errors related to observations
@@ -228,8 +224,7 @@ class AggregateObservationRemovalForm(BaseView):
                 self.get_breadcrumb_dict()),
         }
         try:
-            observation = handle_response(
-                observations.get_metadata(observation_id))
+            observation = observations.get_metadata(observation_id)
         except DataRequestException:
             template_arguments['warnings'] = {
                 'observation': ['Observation could not be read.']
@@ -241,8 +236,7 @@ class AggregateObservationRemovalForm(BaseView):
 
     def get(self, uuid, observation_id, **kwargs):
         try:
-            self.metadata = handle_response(
-                aggregates.get_metadata(uuid))
+            self.metadata = aggregates.get_metadata(uuid)
         except DataRequestException as e:
             return render_template(
                 self.template, errors=e.errors)
@@ -254,8 +248,7 @@ class AggregateObservationRemovalForm(BaseView):
         api_payload = self.aggregate_observation_formatter(
             form_data, observation_id)
         try:
-            handle_response(
-                aggregates.update(uuid, api_payload))
+            aggregates.update(uuid, api_payload)
         except DataRequestException as e:
             if 'observations' in e.errors:
                 # unpack list of errors related to observations
@@ -322,12 +315,12 @@ class AggregateView(BaseView):
         self.temp_args = {}
         start, end = self.parse_start_end_from_querystring()
         try:
-            self.metadata = handle_response(self.api_handle.get_metadata(uuid))
+            self.metadata = self.api_handle.get_metadata(uuid)
         except DataRequestException as e:
             self.temp_args.update({'errors': e.errors})
         else:
             self.observation_list = []
-            observations_list = handle_response(observations.list_metadata())
+            observations_list = observations.list_metadata()
             observation_dict = {obs['observation_id']: obs
                                 for obs in observations_list}
             for obs in self.metadata['observations']:
@@ -363,8 +356,7 @@ class DeleteAggregateView(BaseView):
 
     def get(self, uuid, **kwargs):
         try:
-            self.metadata = handle_response(
-                aggregates.get_metadata(uuid))
+            self.metadata = aggregates.get_metadata(uuid)
         except DataRequestException as e:
             return render_template(self.template, errors=e.errors)
         return super().get(**kwargs)

--- a/sfa_dash/blueprints/base.py
+++ b/sfa_dash/blueprints/base.py
@@ -6,7 +6,7 @@ from flask.views import MethodView
 import pandas as pd
 
 from sfa_dash.errors import DataRequestException
-from sfa_dash.blueprints.util import handle_response, timeseries_adapter
+from sfa_dash.blueprints.util import timeseries_adapter
 
 
 class BaseView(MethodView):
@@ -21,8 +21,8 @@ class BaseView(MethodView):
         the temp_args keys plot and bokeh_script respectively.
         """
         try:
-            values = handle_response(self.api_handle.get_values(
-                uuid, params={'start': start, 'end': end}))
+            values = self.api_handle.get_values(
+                uuid, params={'start': start, 'end': end})
         except DataRequestException as e:
             if e.status_code == 422:
                 self.temp_args.update({'warnings': e.errors})

--- a/sfa_dash/blueprints/dash.py
+++ b/sfa_dash/blueprints/dash.py
@@ -3,7 +3,6 @@ on site-section.
 """
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.api_interface import sites, aggregates
-from sfa_dash.blueprints.util import handle_response
 from sfa_dash.errors import DataRequestException
 from flask import render_template, request, url_for
 
@@ -19,7 +18,7 @@ class DataDashView(BaseView):
         return temp_args
 
     def get_site_metadata(self, site_id):
-        return handle_response(sites.get_metadata(site_id))
+        return sites.get_metadata(site_id)
 
     def set_site_or_aggregate_metadata(self):
         """Searches for a site_id or aggregate_id  in self.metadata
@@ -42,8 +41,8 @@ class DataDashView(BaseView):
                 raise
         elif self.metadata.get('aggregate_id'):
             try:
-                self.metadata['aggregate'] = handle_response(
-                    aggregates.get_metadata(self.metadata['aggregate_id']))
+                self.metadata['aggregate'] = aggregates.get_metadata(
+                    self.metadata['aggregate_id'])
             except DataRequestException:
                 self.temp_args.update({
                     'warnings': {

--- a/sfa_dash/blueprints/data_listing.py
+++ b/sfa_dash/blueprints/data_listing.py
@@ -7,7 +7,7 @@ from flask import render_template, request, url_for
 
 from sfa_dash.api_interface import sites, aggregates
 from sfa_dash.blueprints.base import BaseView
-from sfa_dash.blueprints.util import DataTables, handle_response
+from sfa_dash.blueprints.util import DataTables
 from sfa_dash.filters import human_friendly_datatype
 
 from sfa_dash.errors import DataRequestException
@@ -95,11 +95,9 @@ class DataListingView(BaseView):
         # silently failing and listing all objects.
         if site_id is not None or aggregate_id is not None:
             if site_id is not None:
-                location_metadata = handle_response(
-                    sites.get_metadata(site_id))
+                location_metadata = sites.get_metadata(site_id)
             else:
-                location_metadata = handle_response(
-                    aggregates.get_metadata(aggregate_id))
+                location_metadata = aggregates.get_metadata(aggregate_id)
             template_args['breadcrumb'] = self.breadcrumb_html(
                 self.get_breadcrumb_dict(location_metadata))
         else:

--- a/sfa_dash/blueprints/delete.py
+++ b/sfa_dash/blueprints/delete.py
@@ -3,7 +3,6 @@ from flask import url_for, request, render_template, redirect
 from sfa_dash.api_interface import (sites, observations, forecasts,
                                     cdf_forecast_groups)
 from sfa_dash.blueprints.dash import DataDashView
-from sfa_dash.blueprints.util import handle_response
 from sfa_dash.errors import DataRequestException
 
 
@@ -41,8 +40,7 @@ class DeleteConfirmation(DataDashView):
         request to this endpoint on submission
         """
         try:
-            self.metadata = handle_response(
-                self.api_handle.get_metadata(uuid))
+            self.metadata = self.api_handle.get_metadata(uuid)
         except DataRequestException as e:
             return render_template(self.template, uuid=uuid, errors=e.errors)
         else:
@@ -66,7 +64,7 @@ class DeleteConfirmation(DataDashView):
             # the confirmation page, redirect to confirm.
             return redirect(confirmation_url)
         try:
-            handle_response(self.api_handle.delete(uuid))
+            self.api_handle.delete(uuid)
         except DataRequestException as e:
             return self.get(uuid, errors=e.errors)
         return redirect(url_for(f'data_dashboard.{self.data_type}s'))

--- a/sfa_dash/blueprints/form.py
+++ b/sfa_dash/blueprints/form.py
@@ -11,7 +11,6 @@ from sfa_dash.blueprints.aggregates import (AggregateForm,
                                             AggregateObservationRemovalForm)
 from sfa_dash.blueprints.base import BaseView
 from sfa_dash.blueprints.reports import ReportForm
-from sfa_dash.blueprints.util import handle_response
 from sfa_dash.errors import DataRequestException
 
 
@@ -206,7 +205,7 @@ class MetadataForm(BaseView):
         return forecast_metadata
 
     def get_site_metadata(self, site_id):
-        return handle_response(sites.get_metadata(site_id))
+        return sites.get_metadata(site_id)
 
     def cdf_forecast_formatter(self, forecast_dict):
         cdf_forecast_metadata = self.forecast_formatter(forecast_dict)
@@ -243,8 +242,7 @@ class CreateForm(MetadataForm):
         formatted_form = self.formatter(form_data)
         template_args = {}
         try:
-            created_uuid = handle_response(
-                self.api_handle.post_metadata(formatted_form))
+            created_uuid = self.api_handle.post_metadata(formatted_form)
         except DataRequestException as e:
             if e.status_code == 404:
                 errors = {
@@ -296,7 +294,7 @@ class CreateAggregateForecastForm(MetadataForm):
             raise ValueError(f'No metadata form defined for {data_type}')
 
     def get_aggregate_metadata(self, aggregate_id):
-        return handle_response(aggregates.get_metadata(aggregate_id))
+        return aggregates.get_metadata(aggregate_id)
 
     def render_metadata_section(self, metadata):
         return render_template(
@@ -316,8 +314,7 @@ class CreateAggregateForecastForm(MetadataForm):
         formatted_form = self.formatter(form_data)
         template_args = {}
         try:
-            created_uuid = handle_response(
-                self.api_handle.post_metadata(formatted_form))
+            created_uuid = self.api_handle.post_metadata(formatted_form)
         except DataRequestException as e:
             if e.status_code == 404:
                 errors = {
@@ -372,8 +369,7 @@ class UploadForm(BaseView):
     def get(self, uuid):
         temp_args = {}
         try:
-            metadata_dict = handle_response(
-                self.api_handle.get_metadata(uuid))
+            metadata_dict = self.api_handle.get_metadata(uuid)
             metadata_dict['site_link'] = self.generate_site_link(
                 metadata_dict)
         except DataRequestException as e:
@@ -432,7 +428,7 @@ class UploadForm(BaseView):
         if errors:
             return render_template(self.template, uuid=uuid, errors=errors)
         try:
-            handle_response(post_request)
+            post_request
         except DataRequestException as e:
             return render_template(self.template, uuid=uuid, errors=e.errors)
         else:

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -15,7 +15,7 @@ from sfa_dash.blueprints.reports import (ReportsView, ReportView,
                                          DeleteReportView,
                                          DownloadReportView)
 from sfa_dash.blueprints.sites import SingleSiteView, SitesListingView
-from sfa_dash.blueprints.util import (handle_response, download_timeseries)
+from sfa_dash.blueprints.util import download_timeseries
 from sfa_dash.errors import DataRequestException
 from sfa_dash.filters import human_friendly_datatype
 
@@ -128,8 +128,7 @@ class SingleObjectView(DataDashView):
         # inject the errors into the template arguments and skip
         # any further processing.
         try:
-            self.metadata = handle_response(
-                self.api_handle.get_metadata(uuid))
+            self.metadata = self.api_handle.get_metadata(uuid)
         except DataRequestException as e:
             self.temp_args.update({'errors': e.errors})
         else:
@@ -207,8 +206,7 @@ class SingleCDFForecastGroupView(SingleObjectView):
     def get(self, uuid, **kwargs):
         self.temp_args = {}
         try:
-            self.metadata = handle_response(
-                cdf_forecast_groups.get_metadata(uuid))
+            self.metadata = cdf_forecast_groups.get_metadata(uuid)
         except DataRequestException as e:
             self.temp_args.update({'errors': e.errors})
         else:

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -11,7 +11,7 @@ from sfa_dash.api_interface import (observations, forecasts, sites, reports,
                                     aggregates)
 from sfa_dash.utils import check_sign_zip
 from sfa_dash.blueprints.base import BaseView
-from sfa_dash.blueprints.util import filter_form_fields, handle_response
+from sfa_dash.blueprints.util import filter_form_fields
 from sfa_dash.errors import DataRequestException
 
 
@@ -20,7 +20,7 @@ class ReportsView(BaseView):
 
     def template_args(self):
         try:
-            reports_list = handle_response(reports.list_metadata())
+            reports_list = reports.list_metadata()
         except DataRequestException as e:
             return {'errors': e.errors}
         return {
@@ -36,11 +36,10 @@ class ReportForm(BaseView):
         """Requests the forecasts and observations from
         the api for injecting into the dom as a js variable
         """
-        observation_list = handle_response(
-            observations.list_metadata())
-        forecast_list = handle_response(forecasts.list_metadata())
-        site_list = handle_response(sites.list_metadata())
-        aggregate_list = handle_response(aggregates.list_metadata())
+        observation_list = observations.list_metadata()
+        forecast_list = forecasts.list_metadata()
+        site_list = sites.list_metadata()
+        aggregate_list = aggregates.list_metadata()
         for obs in observation_list:
             del obs['extra_parameters']
         for fx in forecast_list:
@@ -115,7 +114,7 @@ class ReportForm(BaseView):
             }
             return super().get(form_data=api_payload, errors=errors)
         try:
-            report_id = handle_response(reports.post_metadata(api_payload))
+            report_id = reports.post_metadata(api_payload)
         except DataRequestException as e:
             return super().get(form_data=api_payload, errors=e.errors)
         return redirect(url_for(
@@ -187,7 +186,7 @@ class ReportView(BaseView):
         `solarforecastarbiter.datamodel.Report` with processed forecasts and
         observations.
         """
-        metadata = handle_response(reports.get_metadata(uuid))
+        metadata = reports.get_metadata(uuid)
         metadata['report_parameters']['object_pairs'] = []
         self.metadata = metadata
 
@@ -250,7 +249,7 @@ class DeleteReportView(BaseView):
 
     def get(self, uuid):
         try:
-            self.metadata = handle_response(reports.get_metadata(uuid))
+            self.metadata = reports.get_metadata(uuid)
         except DataRequestException as e:
             return render_template(self.template, data_type='report',
                                    uuid=uuid, errors=e.errors)

--- a/sfa_dash/blueprints/sites.py
+++ b/sfa_dash/blueprints/sites.py
@@ -1,4 +1,4 @@
-from sfa_dash.blueprints.util import DataTables, handle_response
+from sfa_dash.blueprints.util import DataTables
 from sfa_dash.blueprints.dash import SiteDashView
 from sfa_dash.api_interface import sites
 from sfa_dash.errors import DataRequestException
@@ -53,8 +53,7 @@ class SingleSiteView(SiteDashView):
 
     def get(self, uuid, **kwargs):
         try:
-            self.metadata = handle_response(
-                sites.get_metadata(uuid))
+            self.metadata = sites.get_metadata(uuid)
         except DataRequestException as e:
             return render_template(self.template, errors=e.errors)
         return render_template(self.template, **self.template_args(**kwargs))


### PR DESCRIPTION
Rather than repeating `handle_response` everywhere, this moves it to wrap the `oauth_request_session` calls in the API interface.