### PR TITLE
add logic to load plots only when shown in metrics section

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ tables==3.5.1
 prometheus_flask_exporter
 sentry_sdk
 blinker
+jsonschema==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'solarforecastarbiter',
         'sentry_sdk',
         'blinker',
-        'prometheus-flask-exporter'
+        'prometheus-flask-exporter',
+        'sqlalchemy_utils',
     ]
 )

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -525,3 +525,24 @@ th.selection-column{
 .datetime-td{
     word-break: break-word;
 }
+
+.plot-attribute-wrapper .plot-attribute-wrapper.loading-plots::after{
+    animation: 1.5s linear infinite spinner;
+    animation-play-state: inherit;
+    border: solid 5px #DDD;
+    border-bottom-color: #8AB;
+    border-radius: 50%;
+    content: "";
+    height: 40px;
+    position: absolute;
+    margin-bottom: 20px;
+    top: 20px;
+    left: 50%;
+    transform: translate3d(-50%, -50%, 0);
+    width: 40px;
+    will-change: transform;
+}
+@keyframes spinner {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}

--- a/sfa_dash/static/js/report-rendering.js
+++ b/sfa_dash/static/js/report-rendering.js
@@ -9,7 +9,6 @@
  * The content inside of the metric-block is arbitrary, this code only alters
  * the layout of the page.
  */
-
 function hideEmptyMetricSections(){
     /* Hide all empty sections after a search for forecast.
      */
@@ -45,6 +44,11 @@ function hideMetricsOnSearch(){
         noMatch = noMatch.add(headers);
     });
     noMatch.attr('hidden', true);
+
+    // Apply sorting and load visible visible plots before hiding empty
+    // sections. 
+    applySorting();
+    loadVisiblePlots();
     hideEmptyMetricSections();
 }
 function genericSort(a, b){
@@ -114,6 +118,9 @@ function createContainerDiv(parentValue, type, value){
                             data-target=".${wrapperClass.replace(/ /g,".")}">
                          <p class="h4 report-plot-section-heading-text">${type}: ${label}</p></a>`)
     wrapper = $(`<div class="plot-attribute-wrapper ${wrapperClass} collapse"></div>`);
+
+    // register callback to load plots when expanded
+    wrapper.on("shown.bs.collapse", loadVisiblePlots);
     return [wrapper, collapse_button]
 }
 
@@ -237,7 +244,6 @@ function sortingLi(sortBy){
 function upButtonCallback(){
     // Move the current element's parent li before the next li in the list.
     $(this).parent().prev().before($(this).parent());
-    applySorting();
     hideMetricsOnSearch();
 }
 
@@ -245,10 +251,26 @@ function upButtonCallback(){
 function downButtonCallback(){
     // Move the current element's parent li after the next li in the list.
     $(this).parent().next().after($(this).parent());
-    applySorting();
     hideMetricsOnSearch();
 }
 
+
+function loadVisiblePlots(){
+    console.log('loading visible plots');
+    for(var key in metric_plots){
+        if(metric_plots.hasOwnProperty(key)){
+            var plotDiv = $(`#${key}`);
+            var isHidden = plotDiv.attr('hidden');
+            var parentVisible = plotDiv.parent().hasClass('show');
+            var plotExists = plotDiv.hasClass('js-plotly-plot');
+            
+            if(!isHidden && !plotExists && parentVisible){
+                console.log("Rendering ", key);
+                Plotly.newPlot(key, metric_plots[key]);
+            }
+        }
+    }
+}
 
 $(document).ready(function(){
     /* Create sorting widgets to insert into the template, we do this here
@@ -266,6 +288,5 @@ $(document).ready(function(){
     metricSortingWrapper.prepend(sortingWidgets);
     metricSortingWrapper.prepend($('<div><b>Use the arrows below to reorder the metrics plots.</b><div>'));
     $('#metric-plot-wrapper').before($(metricSortingWrapper));
-    applySorting();
     hideMetricsOnSearch();
 });

--- a/sfa_dash/static/js/report-rendering.js
+++ b/sfa_dash/static/js/report-rendering.js
@@ -266,7 +266,6 @@ async function renderPlotly(div, plotSpec){
 
 
 function loadVisiblePlots(){
-    console.log('loading visible plots');
     for(var key in metric_plots){
         if(metric_plots.hasOwnProperty(key)){
             var plotDiv = $(`#${key}`);
@@ -275,7 +274,6 @@ function loadVisiblePlots(){
             var plotExists = plotDiv.hasClass('js-plotly-plot');
             
             if(!isHidden && !plotExists && parentVisible){
-                console.log("Rendering ", key);
                 renderPlotly(plotDiv[0], metric_plots[key]);
             }
         }

--- a/sfa_dash/static/js/report-rendering.js
+++ b/sfa_dash/static/js/report-rendering.js
@@ -120,7 +120,12 @@ function createContainerDiv(parentValue, type, value){
     wrapper = $(`<div class="plot-attribute-wrapper ${wrapperClass} collapse"></div>`);
 
     // register callback to load plots when expanded
-    wrapper.on("shown.bs.collapse", loadVisiblePlots);
+    wrapper.on("show.bs.collapse", function(){
+        $(this).addClass('loading-plots');
+    }).on("shown.bs.collapse", function(){
+        loadVisiblePlots();
+        $(this).removeClass('loading-plots');
+    });
     return [wrapper, collapse_button]
 }
 
@@ -255,6 +260,11 @@ function downButtonCallback(){
 }
 
 
+async function renderPlotly(div, plotSpec){
+    Plotly.newPlot(div, plotSpec);
+}
+
+
 function loadVisiblePlots(){
     console.log('loading visible plots');
     for(var key in metric_plots){
@@ -266,7 +276,7 @@ function loadVisiblePlots(){
             
             if(!isHidden && !plotExists && parentVisible){
                 console.log("Rendering ", key);
-                Plotly.newPlot(key, metric_plots[key]);
+                renderPlotly(plotDiv[0], metric_plots[key]);
             }
         }
     }

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -37,6 +37,8 @@
 <script src="/static/js/table-search.js"></script>
 <script src="/static/js/table-checkall.js"></script>
 
+<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+
 {# inject the page_data json variable if provided by jinja #}
 {% if page_data is defined %}
 <script>

--- a/sfa_dash/templates/head.html
+++ b/sfa_dash/templates/head.html
@@ -37,7 +37,7 @@
 <script src="/static/js/table-search.js"></script>
 <script src="/static/js/table-checkall.js"></script>
 
-<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
+<script src="https://cdn.plot.ly/plotly-1.52.3.min.js"></script>
 
 {# inject the page_data json variable if provided by jinja #}
 {% if page_data is defined %}


### PR DESCRIPTION
Supports https://github.com/SolarArbiter/solarforecastarbiter-core/pull/359
Adds a function to load metric plots when they become visible. This function is called whenever sorting or searching happens, or when a metric section is expanded. Currently, loads plots as they become visible and does not remove them. 

This does introduce a slight delay after expanding a section before the plots load, which does increase to a second or two with a large number of plots showing. From testing with ~147 plots (5 fx, 7 metrics, 5 categories) expanding all of the metrics plots does not bog down the browser into being unresponsive. 