### PR TITLE
Hide actions user does not have permission to perform

### DIFF
--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -6,7 +6,8 @@ del get_versions
 import os  # NOQA
 
 
-from flask import Flask, redirect, url_for, render_template, session, request  # NOQA
+from flask import (Flask, redirect, url_for, render_template, session, request,  # NOQA
+                   g)  # NOQA
 from flask_seasurf import SeaSurf  # NOQA
 import sentry_sdk  # NOQA
 from sentry_sdk.integrations.flask import FlaskIntegration  # NOQA
@@ -14,8 +15,9 @@ from sentry_sdk.integrations.flask import FlaskIntegration  # NOQA
 
 from sfa_dash.blueprints.auth0 import (make_auth0_blueprint,  # NOQA
                                        oauth_request_session)  # NOQA
-from sfa_dash.api_interface import users
+from sfa_dash.api_interface import users  # NOQA
 from sfa_dash.database import db, session_storage  # NOQA
+from sfa_dash.errors import DataRequestException  # NOQA
 from sfa_dash.filters import register_jinja_filters  # NOQA
 from sfa_dash.template_globals import template_variables  # NOQA
 from sfa_dash import error_handlers  # NOQA
@@ -80,7 +82,13 @@ def create_app(config=None):
         global_template_args['current_user'] = session.get('userinfo')
         if 'uuid' in request.view_args:
             uuid = request.view_args.get('uuid')
-            global_template_args['allowed_actions'] = users.actions_on(uuid)
+            try:
+                g.allowed_actions = users.actions_on(uuid)['actions']
+            except DataRequestException:
+                # Allow for special cases to later set g.allowed_actions e.g.
+                # cdf_forecast_single, where permissions are dependent on
+                # the parent cdf_forecast_group
+                pass
         global_template_args.update(template_variables())
         return global_template_args
 

--- a/sfa_dash/__init__.py
+++ b/sfa_dash/__init__.py
@@ -14,6 +14,7 @@ from sentry_sdk.integrations.flask import FlaskIntegration  # NOQA
 
 from sfa_dash.blueprints.auth0 import (make_auth0_blueprint,  # NOQA
                                        oauth_request_session)  # NOQA
+from sfa_dash.api_interface import users
 from sfa_dash.database import db, session_storage  # NOQA
 from sfa_dash.filters import register_jinja_filters  # NOQA
 from sfa_dash.template_globals import template_variables  # NOQA
@@ -77,6 +78,9 @@ def create_app(config=None):
         # Injects variables into all rendered templates
         global_template_args = {}
         global_template_args['current_user'] = session.get('userinfo')
+        if 'uuid' in request.view_args:
+            uuid = request.view_args.get('uuid')
+            global_template_args['allowed_actions'] = users.actions_on(uuid)
         global_template_args.update(template_variables())
         return global_template_args
 

--- a/sfa_dash/api_interface/users.py
+++ b/sfa_dash/api_interface/users.py
@@ -45,3 +45,8 @@ def remove_role_by_email(email, role_id):
 def get_email(user_id):
     req = get_request(f'/users/{user_id}/email')
     return req
+
+
+def actions_on(uuid):
+    req = get_request(f'/users/actions-on/{uuid}')
+    return req

--- a/sfa_dash/blueprints/main.py
+++ b/sfa_dash/blueprints/main.py
@@ -1,10 +1,10 @@
 from collections import OrderedDict
 
 
-from flask import Blueprint, render_template, url_for, request
+from flask import Blueprint, render_template, url_for, request, g
 
 
-from sfa_dash.api_interface import (observations, forecasts,
+from sfa_dash.api_interface import (users, observations, forecasts,
                                     cdf_forecasts, cdf_forecast_groups)
 from sfa_dash.blueprints.aggregates import (AggregatesView, AggregateView,
                                             DeleteAggregateView)
@@ -111,10 +111,16 @@ class SingleObjectView(DataDashView):
         self.temp_args['upload_link'] = url_for(
             f'forms.upload_{self.data_type}_data',
             uuid=self.metadata[self.id_key])
+
         if self.data_type != 'cdf_forecast':
             self.temp_args['delete_link'] = url_for(
                 f'data_dashboard.delete_{self.data_type}',
                 uuid=self.metadata[self.id_key])
+        else:
+            # update allowed actions based on parent cdf_forecast_group
+            allowed = users.actions_on(self.metadata['parent'])
+            g.allowed_actions = allowed['actions']
+
         self.temp_args['period_start_date'] = start.strftime('%Y-%m-%d')
         self.temp_args['period_start_time'] = start.strftime('%H:%M')
         self.temp_args['period_end_date'] = end.strftime('%Y-%m-%d')

--- a/sfa_dash/template_globals.py
+++ b/sfa_dash/template_globals.py
@@ -3,6 +3,7 @@
 # the template_variables function.
 
 import pytz
+from flask import g
 
 import sfa_dash
 from sfa_dash import filters
@@ -32,6 +33,23 @@ ALLOWED_QUALITY_FLAGS = {
 }
 
 
+def is_allowed(action):
+    """Returns if the action is allowed or not on the current object.
+
+    Parameters
+    ----------
+    action: str
+        The action to query for permission.
+
+    Returns
+    -------
+    bool
+        If the action is allowed or not.
+    """
+    allowed = getattr(g, 'allowed_actions', [])
+    return action in allowed
+
+
 def template_variables():
     return {
         'dashboard_version': sfa_dash.__version__,
@@ -41,5 +59,6 @@ def template_variables():
         'metric_categories': ALLOWED_CATEGORIES,
         'deterministic_metrics': ALLOWED_DETERMINISTIC_METRICS,
         'default_metrics': DEFAULT_METRICS,
-        'quality_flags': ALLOWED_QUALITY_FLAGS
+        'quality_flags': ALLOWED_QUALITY_FLAGS,
+        'is_allowed': is_allowed
     }

--- a/sfa_dash/templates/data/aggregate.html
+++ b/sfa_dash/templates/data/aggregate.html
@@ -4,13 +4,23 @@
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
 {% if aggregate is defined %}
+
+{% set update_allowed = is_allowed('update') %}
+{% if update_allowed %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.add_aggregate_observations', uuid=aggregate['aggregate_id'] ) }}">Add Observation</a>
+{% endif %}
+
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_aggregate_forecast', uuid=aggregate['aggregate_id'] ) }}">Create Forecast</a>
+
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_aggregate_cdf_forecast_group', uuid=aggregate['aggregate_id'] ) }}">Create Probabilistic Forecast</a>
-{% if upload_link is defined %}
+
+{% if upload_link is defined and is_allowed('write_values') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{upload_link}}">Upload data</a>
 {% endif %}
+
+{% if is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_aggregate', uuid=aggregate['aggregate_id']) }}">Delete</a>
+{% endif %}
 
 <h3 class="mt-3">Observations</h3>
 <div class="tools aggregate-observation-tools mt-1">
@@ -38,7 +48,9 @@
         {% if obs["effective_until"] is not none %}
         <td scope="col" class="effective-until-column datetime-td">{{ obs["effective_until"] | format_datetime}}</td>
         {% else %}
+        {% if update_allowed %}
         <td scope="col"><a href="{{ url_for('forms.remove_aggregate_observations', uuid=aggregate['aggregate_id'], observation_id=obs['observation_id']) }}">Set Effective Until</a></td>
+        {% endif %}
         {% endif %}
     </tr>
     {% endfor %}

--- a/sfa_dash/templates/data/asset.html
+++ b/sfa_dash/templates/data/asset.html
@@ -2,12 +2,10 @@
 {% import "forms/form_macros.jinja" as form %}
 {% block content %}
 {{ metadata | safe }}
-{% if upload_link is defined %}
+{% if upload_link is defined and is_allowed('write_values') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{upload_link}}">Upload data</a>
 {% endif %}
-{% if download_link is defined %}
-{% endif %}
-{% if delete_link is defined %}
+{% if delete_link is defined and is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
 {% include "sections/notifications.html" %}

--- a/sfa_dash/templates/data/cdf_forecast.html
+++ b/sfa_dash/templates/data/cdf_forecast.html
@@ -1,13 +1,13 @@
 {% extends "dash/data.html" %}
 {% block content %}
 {{ metadata | safe }}
-{% if upload_link is defined %}
+{% if upload_link is defined and is_allowed('write_values') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{upload_link}}">Upload data</a>
 {% endif %}
-{% if download_link is defined %}
+{% if download_link is defined and is_allowed('read_values') %}
 <a role="button" class="btn btn-primary btn-sm" href="{{download_link}}">Download data</a>
 {% endif %}
-{% if delete_link is defined %}
+{% if delete_link is defined and is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ delete_link }}">Delete</a>
 {% endif %}
 {% include "sections/notifications.html" %}

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -7,10 +7,10 @@
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_observation', uuid=site_id) }}">Create new Observation</a>
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_forecast', uuid=site_id) }}">Create new Forecast</a>
   <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('forms.create_cdf_forecast_group', uuid=site_id) }}">Create new Probabilistic Forecast</a>
+  {% if is_allowed('delete') %}
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
-
+  {% endif %}
 {% endblock %}
-{{ allowed_actions }}
 {{ listing | safe }}
 {% endif %}
 {% endblock %}

--- a/sfa_dash/templates/data/site.html
+++ b/sfa_dash/templates/data/site.html
@@ -10,6 +10,7 @@
   <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('data_dashboard.delete_site', uuid=site_id) }}">Delete this site</a>
 
 {% endblock %}
+{{ allowed_actions }}
 {{ listing | safe }}
 {% endif %}
 {% endblock %}

--- a/sfa_dash/templates/data/time_widgets.html
+++ b/sfa_dash/templates/data/time_widgets.html
@@ -1,4 +1,6 @@
 {% import "forms/form_macros.jinja" as form %}
+
+{% if is_allowed('read_values') %}
 {# Time widgets are used for either setting the bounds of the plot or download #}
 <div class="form-group mt-3">
 <div class="form-element">
@@ -15,13 +17,11 @@
 <div class="form-element full-width">
   <button type="submit" form="plot-range-adjust" value="Submit" class="btn btn-primary">Update graph</button>
   <form action="" method="post" id="download-form" onsubmit="ParseStartEnd()">
-  {% if is_allowed('read_values') %}
   <button type="submit" form="download-form" value="Submit" class="btn btn-primary">Download data</button>
   <label for="format">Format: </label>
   <input type="radio" name="format" value="text/csv" checked>CSV</input>
   <input type="radio" name="format" value="application/json">JSON</input>
   &lpar;<a href="https://solarforecastarbiter.org/datamodel/#downloads" target="_blank">format examples</a>&rpar;
-  {% endif %}
   <input type="text" class="start" name="start" hidden>
   <input type="text" class="end" name="end" hidden>
   {{ form.token() }}
@@ -32,3 +32,4 @@
 <input type="text" class="start" name="start" hidden>
 <input type="text" class="end" name="end" hidden>
 <script src="/static/js/plot-bound-parsing.js"></script>
+{% endif %}

--- a/sfa_dash/templates/data/time_widgets.html
+++ b/sfa_dash/templates/data/time_widgets.html
@@ -15,11 +15,13 @@
 <div class="form-element full-width">
   <button type="submit" form="plot-range-adjust" value="Submit" class="btn btn-primary">Update graph</button>
   <form action="" method="post" id="download-form" onsubmit="ParseStartEnd()">
+  {% if is_allowed('read_values') %}
   <button type="submit" form="download-form" value="Submit" class="btn btn-primary">Download data</button>
   <label for="format">Format: </label>
   <input type="radio" name="format" value="text/csv" checked>CSV</input>
   <input type="radio" name="format" value="application/json">JSON</input>
   &lpar;<a href="https://solarforecastarbiter.org/datamodel/#downloads" target="_blank">format examples</a>&rpar;
+  {% endif %}
   <input type="text" class="start" name="start" hidden>
   <input type="text" class="end" name="end" hidden>
   {{ form.token() }}

--- a/sfa_dash/templates/forms/admin/permission.html
+++ b/sfa_dash/templates/forms/admin/permission.html
@@ -4,10 +4,16 @@
 {% include 'sections/notifications.html' %}
 {% if permission is defined %}
 {% include 'data/metadata/permission_metadata.html' %}
-{% if not permission['applies_to_all'] %}
+
+{% set update_allowed = is_allowed('update') %}
+{% if not permission['applies_to_all'] and update_allowed %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('admin.permission_object_addition', uuid=permission['permission_id']) }}">Add Objects to Permission</a>
 {% endif %}
+
+{% if is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('admin.delete_permission', uuid=permission['permission_id']) }}">Delete</a>
+{% endif %}
+
 <h3 class="my-3">{{ permission['object_type'] | title }}</h3>
 <div class="tools {{ table_type }}-tools mt-1">
    {% block tools %}
@@ -37,7 +43,7 @@
           {% endif %}
         {% endif %}
         <td>{{ obj['added_to_permission'] | format_datetime}} </td>
-        {% if not permission['applies_to_all'] %}
+        {% if not permission['applies_to_all'] and update_allowed %}
         <td><a role="button" class="permission-object-delete-button" href="{{ url_for('admin.permission_object_removal', uuid=permission['permission_id'], object_id=uuid)}}">Remove</a></td>
         {% endif %}
       </tr>

--- a/sfa_dash/templates/forms/admin/role.html
+++ b/sfa_dash/templates/forms/admin/role.html
@@ -4,9 +4,22 @@
 {% include "sections/notifications.html" %}
 {% if role is defined %}
 {% include 'data/metadata/role_metadata.html' %}
+
+{% set revoke_allowed = is_allowed('revoke') %}
+
+{% set update_allowed = is_allowed('update') %}
+{% if update_allowed %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('admin.role_perm_addition', uuid=role['role_id']) }}">Add Permissions</a>
+{% endif %}
+
+{% set grant_allowed = is_allowed('grant') %}
+{% if grant_allowed %}
 <a role="button" class="btn btn-primary btn-sm" href="{{ url_for('admin.role_grant', uuid=role['role_id']) }}">Grant Role</a>
+{% endif %}
+
+{% if is_allowed('delete') %}
 <a role="button" class="btn btn-danger btn-sm" href="{{ url_for('admin.delete_role', uuid=role['role_id']) }}">Delete</a>
+{% endif %}
 
 <ul class="mt-2 nav nav-tabs">
     <li class="nav-item {% if role_table == 'permissions' %}active{% endif %}"><a class="nav-link" href="{{ url_for('admin.role_view', uuid=role['role_id'], table='permissions') }}">Permissions</a></li>
@@ -32,7 +45,11 @@
       <tr>
           <td><a href="{{ url_for('admin.permission_view', uuid=perm_id) }}">{{ perm['description'] }}</a></td>
           <td>{{ perm['added_to_role'] | format_datetime}}</td>
-          <td><a role="button" class="role-permission-delete-button" href="{{ url_for('admin.role_perm_removal', uuid=role['role_id'], permission_id=perm['permission_id']) }}">Remove</a></td>
+          <td>
+            {% if update_allowed %}
+            <a role="button" class="role-permission-delete-button" href="{{ url_for('admin.role_perm_removal', uuid=role['role_id'], permission_id=perm['permission_id']) }}">Remove</a>
+            {% endif %}
+          </td>
       </tr>
     {% endfor %}
   </tbody>
@@ -57,7 +74,11 @@
       <tr>
           <td class="email-column"><a href="{{ url_for('admin.user_view', uuid=user['user_id']) }}"> {{ user['email'] }} </a></td>
           <td class="provider-column">{{ user['organization'] }} </td>
-          <td><a href={{ url_for('admin.user_role_removal', uuid=user_id, role_id=role['role_id']) }}>Remove</a></td>
+          <td>
+            {% if revoke_allowed %}
+            <a href={{ url_for('admin.user_role_removal', uuid=user_id, role_id=role['role_id']) }}>Remove</a>
+            {% endif %}
+          </td>
       </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
Uses the `actions-on` endpoint added in https://github.com/SolarArbiter/solarforecastarbiter-api/pull/221 to provide a list of allowable actions for the current object and expose the `is_allowed` function to jinja templates. These actions are then used to hide some dashboard functionality. This works nicely for single object pages, e.g. A site, or observation.

There are a couple of shortcomings that It would be nice to remedy:
- Create permissions are only related to an object type, and cannot be queried by uuid as the endpoint I added is set up. Maybe a list of object types the user is capable of creating is always returned from these endpoints?

- Listing pages where delete or update buttons have been addded to the row for convenience are not hidden. For example, the reports listing page has a delete button for each report in the table. Querying for each of the listed objects is expensive, so a bulk actions query endpoint may be in order if it does not turn out to be terribly inefficient in mysql.