### PR TITLE
Support reference forecasts, uncertainty, unit consistency

### DIFF
--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -75,12 +75,12 @@ class ReportForm(BaseView):
 
         reference_forecasts = filter_form_fields('reference-forecast-',
                                                  form_data)
+
         uncertainty_values = filter_form_fields('deadband-value-', form_data)
         pairs = [{'forecast': f,
                   truth_types[i]: truth_ids[i],
                   'reference_forecast': reference_forecasts[i],
-                  'uncertainty': uncertainty_values[i],
-                 }
+                  'uncertainty': uncertainty_values[i]}
                  for i, f in enumerate(fx)]
         return pairs
 

--- a/sfa_dash/blueprints/reports.py
+++ b/sfa_dash/blueprints/reports.py
@@ -72,7 +72,15 @@ class ReportForm(BaseView):
         # appropriately indexed forecast.
         truth_ids = filter_form_fields('truth-id-', form_data)
         truth_types = filter_form_fields('truth-type-', form_data)
-        pairs = [{'forecast': f, truth_types[i]: truth_ids[i]}
+
+        reference_forecasts = filter_form_fields('reference-forecast-',
+                                                 form_data)
+        uncertainty_values = filter_form_fields('deadband-value-', form_data)
+        pairs = [{'forecast': f,
+                  truth_types[i]: truth_ids[i],
+                  'reference_forecast': reference_forecasts[i],
+                  'uncertainty': uncertainty_values[i],
+                 }
                  for i, f in enumerate(fx)]
         return pairs
 

--- a/sfa_dash/blueprints/util.py
+++ b/sfa_dash/blueprints/util.py
@@ -283,9 +283,10 @@ def filter_form_fields(prefix, form_data):
     list
         List of all values where the corresponding key began with prefix.
     """
-    return [form_data[key]
-            for key in form_data.keys()
-            if key.startswith(prefix)]
+    values = [form_data[key]
+              for key in form_data.keys()
+              if key.startswith(prefix)]
+    return [None if v == 'null' else v for v in values]
 
 
 def parse_timedelta(data_dict, key_root):

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -173,16 +173,24 @@ ul.data-metadata-fields{
 }
 
 /* Forms */
-li.object-pair {
+div.object-pair {
   list-style: none;
-  padding-right: 1em;
+  padding: .5em 1em;
   position: relative;
+  border: 1px solid #333;
+  border-radius: 5px;
 }
-ul.object-pair-list{
+div.object-pair-label{
+    font-size: 16px;
+}
+div.object-pair-list{
   padding-left: 0;
+  margin-bottom: 1em;
 }
 a.object-pair-delete-button{
-    top: 50%;
+    position: absolute;
+    top: 5px;
+    right: 20px;
     color: #A00 !important;
 }
 .form-group{
@@ -545,4 +553,8 @@ th.selection-column{
 @keyframes spinner {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
+}
+
+#form-errors .alert{
+    list-style: none;
 }

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -179,6 +179,7 @@ div.object-pair {
   position: relative;
   border: 1px solid #333;
   border-radius: 5px;
+  margin-bottom: .5em;
 }
 div.object-pair-label{
     font-size: 16px;

--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -558,3 +558,7 @@ th.selection-column{
 #form-errors .alert{
     list-style: none;
 }
+.warning-message{
+    font-weight: bold;
+    color: #A11;
+}

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -2,6 +2,55 @@
  *  Creates inputs for defining observation, forecast pairs for a report.
  */
 $(document).ready(function() {
+    var variable_unit_map = {
+        'air_temperature': 'degC',
+        'wind_speed': 'm/s',
+        'ghi': 'W/m^2',
+        'dni': 'W/m^2',
+        'dhi': 'W/m^2',
+        'poa_global': 'W/m^2',
+        'relative_humidity': '%',
+        'ac_power': 'MW',
+        'dc_power': 'MW',
+        'availability': '%',
+        'curtailment': 'MW',
+    }
+    var current_units = null;
+    
+    function unset_units(){
+        /* Set units to null when the last pair is removed */
+        current_units = null;
+        setVariables()
+    }
+    function set_units(variable){
+        console.log('setting units with var ', variable);
+        units = variable_unit_map[variable];
+        if(units){
+            current_units = units;
+        }
+        setVariables();
+    }
+
+    function setVariables(){
+        variable_options = $('#variable-select option');
+        variable_options.removeAttr('hidden');
+        variable_options.removeAttr('disabled');
+        if (current_units){
+            variable_options.each(function(){
+                units = variable_unit_map[$(this).attr('value')]
+                if(units != current_units){
+                    $(this).attr('hidden', true);
+                    $(this).attr('disabled', true);
+                }
+            });
+        }
+        $('#variable-select').val(variable_options.filter(":not([hidden])").val());
+    }
+    function changeVariable(){
+        setVariables(); 
+        filterForecasts();
+    }
+
     function registerDatetimeValidator(input_name){
         /*
          * Applies a regex validator to ensure ISO8601 compliance. This is however, very strict. We
@@ -38,7 +87,10 @@ $(document).ready(function() {
         }
         variables = new Set();
         for (fx in page_data['forecasts']){
-            variables.add(page_data['forecasts'][fx].variable);
+            var new_var = page_data['forecasts'][fx].variable;
+            if (!current_units || variable_unit_map[new_var] == current_units){
+                variables.add(page_data['forecasts'][fx].variable);
+            }
         }
         variable_select = $('<select id="variable-select" class="form-control half-width"><option selected value>All Variables</option></select>');
         variables.forEach(function(variable){
@@ -62,7 +114,14 @@ $(document).ready(function() {
         return $(selectSelector + " option").slice(offset).not(":containsi('" + searchSplit + "')");
     }
 
-    function addPair(truthType, truthName, truthId, fxName, fxId){
+    function applyFxDependentFilters(){
+        filterObservations();
+        filterAggregates();
+        filterReferenceForecasts();
+    }
+
+    function addPair(truthType, truthName, truthId, fxName, fxId,
+                     ref_fxName, ref_fxId){
         /*
          * Returns a Jquery object containing 5 input elements representing a forecast,
          * observation pair:
@@ -76,39 +135,41 @@ $(document).ready(function() {
          */
         var new_object_pair = $(`<div class="object-pair object-pair-${pair_index}">
                 <div class="input-wrapper">
-                  <div class="col-md-6">
-                    <input type="text" class="form-control forecast-field" name="forecast-name-${pair_index}" required disabled value="${fxName}"/>
-                    <input type="hidden" class="form-control forecast-field" name="forecast-id-${pair_index}" required value="${fxId}"/>
-                  </div>
-                  <div class="col-md-6">
-                    <input type="text" class="form-control truth-field" name="truth-name-${pair_index}"  required disabled value="${truthName}"/>
-                    <input type="hidden" class="form-control truth-field" name="truth-id-${pair_index}" required value="${truthId}"/>
-                    <input type="hidden" class="form-control truth-field" name="truth-type-${pair_index}" required value="${truthType}"/>
+                  <div class="col-md-12">
+                    <div class="object-pair-label forecast-name-${pair_index}"><b>Forecast: </b>${fxName}</div>
+                    <input type="hidden" class="form-control forecast-value" name="forecast-id-${pair_index}" required value="${fxId}"/>
+                    <div class="object-pair-label truth-name-${pair_index}"><b>Observation: </b> ${truthName}</div>
+                    <input type="hidden" class="form-control truth-value" name="truth-id-${pair_index}" required value="${truthId}"/>
+                    <input type="hidden" class="form-control truth-type-value" name="truth-type-${pair_index}" required value="${truthType}"/>
+                    <div class="object-pair-label reference-forecast-name-${pair_index}"><b>Reference Forecast: </b> ${ref_fxName}</div>
+                    <input type="hidden" class="form-control reference-forecast-value" name="reference-forecast-${pair_index}" required value="${ref_fxId}"/>
                   </div>
                  </div>
-                 <a role="button" class="object-pair-delete-button">x</a>
+                 <a role="button" class="object-pair-delete-button">remove</a>
                </div>`);
         var remove_button = new_object_pair.find(".object-pair-delete-button");
         remove_button.click(function(){
             new_object_pair.remove();
             if ($('.object-pair-list .object-pair').length == 0){
                 $('.empty-reports-list')[0].hidden = false;
+                unset_units();
             }
         });
         return new_object_pair;
     }
 
 
-    function newSelector(field_type, depends_on=null){
+    function newSelector(field_name, depends_on=null, required=true){
         /*
          * Returns a JQuery object containing labels and select elements for appending options to.
          * Initializes with one default and one optional select option:
          *     Always adds an option containing "No matching <field_Type>s
          *     If depends_on is provided, inserts a "Please select a <depends_on> option>
          */
+        var field_type = field_name.toLowerCase().replace(' ', '-');
         return $(`<div class="form-element full-width ${field_type}-select-wrapper">
-                    <label>Select a ${field_type}</label>
-                      <div class="report-field-filters"><input id="${field_type}-option-search" class="form-control half-width" placeholder="Search by ${field_type} name"/></div><br>
+                    <label>Select a ${field_name} ${required ? "" : "(Optional)"}</label>
+                      <div class="report-field-filters"><input id="${field_type}-option-search" class="form-control half-width" placeholder="Search by ${field_name} name"/></div><br>
                     <div class="input-wrapper">
                       <select id="${field_type}-select" class="form-control ${field_type}-field" name="${field_type}-select" size="5">
                       ${depends_on ? `<option id="no-${field_type}-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
@@ -225,10 +286,76 @@ $(document).ready(function() {
             } else {
                 $('#no-forecasts').attr('hidden', true);
             }
+            filterReferenceForecasts(variable);
             if (compareTo == 'observation'){
                 filterObservations();
             } else {
                 filterAggregates();
+            }
+        }
+
+        function filterReferenceForecasts(variable){
+            forecast = forecast_select.find(':selected').first();
+            reference_forecasts = $('#reference-forecast-select option').slice(2);
+            reference_forecasts.removeAttr('hidden');
+            if (forecast[0]){
+                console.log("selected forecast ", forecast);
+                if(forecast.data.hasOwnProperty('siteId')){
+                    site_id = forecast.data().siteId;
+                }else{
+                    aggregate_id = forecast.data().aggregateId;
+                }
+                variable = forecast.data().variable;
+                console.log('selected variable ', variable);
+                interval_length = forecast.data().intervalLength;
+                console.log('selected il ', interval_length);
+                // hide the "please select forecast" prompt"
+                $('#no-reference-forecast-forecast-selection').attr('hidden', true);
+                toHide = searchSelect('#reference-forecast-option-search',
+                                  '#reference-forecast-select', 2);
+                if (variable){
+                toHide = toHide.add(reference_forecasts.not(
+                    `[data-variable=${variable}]`));
+                }
+                console.log("after var", toHide);
+                // Determine if we need to filter by site or aggregate
+                if (site_id){
+                    // create a set of elements to hide from selected site, variable and search
+                    toHide = toHide.add(reference_forecasts.not(
+                        `[data-site-id=${site_id}]`));
+                } else {
+                    toHide = toHide.add(
+                        reference_forecasts.not(
+                            `[data-aggregate-id=${aggregate_id}]`));
+                }
+                // Filter out reference forecasts that don't have the same
+                // interval length
+                things = reference_forecasts.filter(function(){
+                    return $(this).data().intervalLength != interval_length ||
+                        $(this).attr('value') == forecast_select.val();
+                });
+                toHide = toHide.add(things);
+            }else{
+                toHide = reference_forecasts;
+                $('#no-reference-forecast-forecast-selection').removeAttr('hidden');
+                console.log('no forecast');
+            }
+            
+            console.log("after search", toHide);
+            
+            // if current forecast selection is invalid, deselect
+            if (toHide.filter(':selected').length){
+                ref_forecast_select.val('');
+            }
+            toHide.attr('hidden', 'true');
+            // if all options are hidden, show "no matching forecasts"
+            if (toHide.length == reference_forecasts.length){
+                ref_forecast_select.val('');
+                if ($('#no-reference-forecast-site-selection').attr('hidden') || compareTo == 'aggregate'){
+                    $('#no-reference-forecasts').removeAttr('hidden');
+                }
+            } else {
+                $('#no-reference-forecasts').attr('hidden', true);
             }
         }
 
@@ -304,6 +431,7 @@ $(document).ready(function() {
         var siteSelector = newSelector("site");
         var obsSelector = newSelector("observation", "forecast");
         var fxSelector = newSelector("forecast", "site");
+        var refFxSelector = newSelector("reference forecast", "forecast", required=false);
         var fxVariableSelector = createVariableSelect();
         fxSelector.find('.report-field-filters').append(fxVariableSelector);
         var addObsButton = $('<a role="button" class="btn btn-primary" id="add-obs-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
@@ -322,6 +450,7 @@ $(document).ready(function() {
         // be inserted into the DOM
         widgetContainer.append(siteSelector);
         widgetContainer.append(fxSelector);
+        widgetContainer.append(refFxSelector);
         widgetContainer.append(obsSelector);
         widgetContainer.append(aggregateSelector);
         widgetContainer.append(addObsButton);
@@ -335,18 +464,22 @@ $(document).ready(function() {
         siteSelector.find('#site-option-search').keyup(filterSites);
         obsSelector.find('#observation-option-search').keyup(filterObservations);
         fxSelector.find('#forecast-option-search').keyup(filterForecasts);
+        fxSelector.find('#reference-forecast-option-search').keyup(filterForecasts);
         aggregateSelector.find('#aggregate-option-search').keyup(filterAggregates);
 
         // create variables pointing to the specific select elements
         var observation_select = obsSelector.find('#observation-select');
         var forecast_select = fxSelector.find('#forecast-select');
+        var ref_forecast_select = refFxSelector.find('#reference-forecast-select');
         var site_select = siteSelector.find('#site-select');
         var aggregate_select = aggregateSelector.find('#aggregate-select');
         
+        // set callbacks for select inputs
         site_select.change(filterForecasts);
         variable_select.change(filterForecasts);
         forecast_select.change(filterObservations);
         forecast_select.change(filterAggregates);
+        forecast_select.change(filterReferenceForecasts);
 
         // insert options from page_data into the select elements
         $.each(page_data['sites'], function(){
@@ -367,8 +500,17 @@ $(document).ready(function() {
                     .attr('data-variable', this.variable));
         });
         $.each(page_data['forecasts'], function(){
-            forecast_select.append(
-                $('<option></option>')
+            forecast_select.append($('<option></option>')
+                    .html(this.name)
+                    .val(this.forecast_id)
+                    .attr('hidden', true)
+                    .attr('data-site-id', this.site_id)
+                    .attr('data-aggregate-id', this.aggregate_id)
+                    .attr('data-interval-length', this.interval_length)
+                    .attr('data-variable', this.variable));
+        });
+        $.each(page_data['forecasts'], function(){
+            ref_forecast_select.append($('<option></option>')
                     .html(this.name)
                     .val(this.forecast_id)
                     .attr('hidden', true)
@@ -399,15 +541,28 @@ $(document).ready(function() {
                 // If both inputs contain valid data, create a pair and add it to the DOM
                 var selected_observation = observation_select.find('option:selected')[0];
                 var selected_forecast = forecast_select.find('option:selected')[0];
+                var selected_reference_forecast = ref_forecast_select.find('option:selected')[0];
+                if(!selected_reference_forecast){
+                    ref_text = "Unset";
+                    ref_id = null;
+                }else{
+                    ref_text = selected_reference_forecast.text;
+                    ref_id = selected_reference_forecast.value;
+                }
+
                 pair = addPair('observation',
                                selected_observation.text,
                                selected_observation.value,
                                selected_forecast.text,
-                               selected_forecast.value);
-
+                               selected_forecast.value,
+                               ref_text,
+                               ref_id,
+                );
                 pair_container.append(pair);
                 pair_index++;
-                $(".empty-reports-list")[0].hidden = true;
+                var variable = selected_forecast.dataset.variable;
+                set_units(variable);
+                $(".empty-reports-list").attr('hidden', 'hidden');
                 forecast_select.css('border', '');
                 observation_select.css('border', '');
             } else {
@@ -427,13 +582,27 @@ $(document).ready(function() {
             if (aggregate_select.val() && forecast_select.val()){
                 var selected_aggregate = aggregate_select.find('option:selected')[0];
                 var selected_forecast = forecast_select.find('option:selected')[0];
+                var selected_reference_forecast = ref_forecast_select.find('option:selected')[0];
+                if(!selected_reference_forecast){
+                    ref_text = "Unset";
+                    ref_id = null;
+                }else{
+                    ref_text = selected_reference_forecast.text;
+                    ref_id = selected_reference_forecast.value;
+                }
                 pair = addPair('aggregate',
                                selected_aggregate.text,
                                selected_aggregate.value,
                                selected_forecast.text,
-                               selected_forecast.value);
+                               selected_forecast.value,
+                               ref_text,
+                               ref_id,
+                );
                 pair_container.append(pair);
                 pair_index++;
+                var variable = selected_forecast.dataset.variable;
+                set_units(variable);
+
                 $(".empty-reports-list")[0].hidden = true;
                 forecast_select.css('border', '');
                 observation_select.css('border', '');
@@ -467,3 +636,33 @@ $(document).ready(function() {
     registerDatetimeValidator('period-start');
     registerDatetimeValidator('period-end')
 });
+
+
+function insertErrorMessage(title, msg){
+    $('#form-errors').append(`<li class="alert alert-danger"><p><b>${title}: </b>${msg}</p></li>`);
+}
+function validateReport(){
+    /*
+     * Callback before the report form is submitted. Any js validation should
+     * occur here.
+     */
+    // remove any existing errors
+    $('#form-errors').empty();
+
+    // Assert that if skill is selected, all pairs have a reference forecast.
+    selected_metrics = $('input[name="metrics"]').map(function(){return this.value}).get();
+    reference_forecasts = $('.reference-forecast-value').map(function(){return this.value}).get();
+    if(selected_metrics.includes("s") && reference_forecasts.some((x) => x != 'Unset')){
+        insertErrorMessage(
+            "Skill Metric",
+            "Requires that all Observation, Forecast pairs have a reference forecast.");
+    }
+
+    // asset at least one pair was selected.
+    if($('.object-pair').length == 0){
+        insertErrorMessage(
+            "Analysis Pairs",
+            "Must specify at least one Observation, Forecast pair.");
+    }
+    return false;
+}

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -2,6 +2,47 @@
  *  Creates inputs for defining observation, forecast pairs for a report.
  */
 $(document).ready(function() {
+    function toggle_reference_dependent_metrics(){
+        /*
+         * Disables and de-selects the forecast skill metric if not all of the
+         * object pairs have reference foreasts.
+         */
+        var nulls_exist = $('.reference-forecast-value').map(function(){return $(this).val()}).get().some(x=>x=='null');
+        var skill = $('[name=metrics][value=s]'); 
+        if(nulls_exist){
+            // hide skill, insert warning
+            skill.attr('disabled', true);
+            $('<span id="reference-warning" class="warning-message"> (Requires reference forecast selection)</span>').insertAfter(skill.next());
+            if(skill.is(':checked')){
+                skill.removeAttr('checked');
+            }
+        }else{
+            // show skill remove warning
+            skill.removeAttr('disabled');
+            $('#reference-warning').remove();
+        }
+    }
+    function searchObjects(object_type, object_id){
+        /* Get a json object from the page_data object.
+         *
+         * @param {string} object_type - The type of the object to search for.
+         *     One of 'forecasts', 'sites', 'observations', 'aggregates'.
+         *
+         * @param {string} object_id - UUID of the object to search for
+         *
+         * @returns {Object} An object containing the SFA object's metadata.
+         */
+        try{
+            var objects = page_data[object_type];
+            var id_prop = object_type.slice(0, -1) + '_id';
+            var metadata = objects.find(e => e[id_prop] == object_id);
+        }catch(error){
+            return null;
+        }
+        return metadata;
+    }
+
+
     var variable_unit_map = {
         'air_temperature': 'degC',
         'wind_speed': 'm/s',
@@ -15,6 +56,8 @@ $(document).ready(function() {
         'availability': '%',
         'curtailment': 'MW',
     }
+
+
     var current_units = null;
     
     function unset_units(){
@@ -22,14 +65,16 @@ $(document).ready(function() {
         current_units = null;
         setVariables()
     }
+
+
     function set_units(variable){
-        console.log('setting units with var ', variable);
         units = variable_unit_map[variable];
         if(units){
             current_units = units;
         }
         setVariables();
     }
+
 
     function setVariables(){
         variable_options = $('#variable-select option');
@@ -121,7 +166,7 @@ $(document).ready(function() {
     }
 
     function addPair(truthType, truthName, truthId, fxName, fxId,
-                     ref_fxName, ref_fxId){
+                     ref_fxName, ref_fxId, db_label, db_value){
         /*
          * Returns a Jquery object containing 5 input elements representing a forecast,
          * observation pair:
@@ -130,9 +175,14 @@ $(document).ready(function() {
          *  truth-name-<indeX>
          *  truth-id-<indeX>
          *  truth-type-<index>
+         *  ref_fxName,
+         *  ref_fxId,
+         *  db_label,
+         *  db_value,
          *  where index associates the pairs with eachother for easier parsing when the form
          *  is submitted.
          */
+
         var new_object_pair = $(`<div class="object-pair object-pair-${pair_index}">
                 <div class="input-wrapper">
                   <div class="col-md-12">
@@ -141,8 +191,10 @@ $(document).ready(function() {
                     <div class="object-pair-label truth-name-${pair_index}"><b>Observation: </b> ${truthName}</div>
                     <input type="hidden" class="form-control truth-value" name="truth-id-${pair_index}" required value="${truthId}"/>
                     <input type="hidden" class="form-control truth-type-value" name="truth-type-${pair_index}" required value="${truthType}"/>
-                    <div class="object-pair-label reference-forecast-name-${pair_index}"><b>Reference Forecast: </b> ${ref_fxName}</div>
+                    <div class="object-pair-label reference-forecast-name"><b>Reference Forecast: </b> ${ref_fxName}</div>
                     <input type="hidden" class="form-control reference-forecast-value" name="reference-forecast-${pair_index}" required value="${ref_fxId}"/>
+                    <div class="object-pair-label deadband-label"><b>Uncertainty: </b> ${db_label}</div>
+                    <input type="hidden" class="form-control deadband-value" name="deadband-value-${pair_index}" required value="${db_value}"/>
                   </div>
                  </div>
                  <a role="button" class="object-pair-delete-button">remove</a>
@@ -154,6 +206,7 @@ $(document).ready(function() {
                 $('.empty-reports-list')[0].hidden = false;
                 unset_units();
             }
+            toggle_reference_dependent_metrics();
         });
         return new_object_pair;
     }
@@ -173,10 +226,55 @@ $(document).ready(function() {
                     <div class="input-wrapper">
                       <select id="${field_type}-select" class="form-control ${field_type}-field" name="${field_type}-select" size="5">
                       ${depends_on ? `<option id="no-${field_type}-${depends_on}-selection" disabled> Please select a ${depends_on}.</option>` : ""}
-                      <option id="no-${field_type}s" disabled hidden>No matching ${field_type}s</option>
+                      <option id="no-${field_type}s" disabled hidden>No matching ${field_name}s</option>
                     </select>
                     </div>
                   </div>`);
+    }
+
+
+    function deadbandSelector(){
+        /*
+         * Create a radio button and text input for selecting an uncertainty
+         * deadband
+         */
+        var deadbandSelect= $(
+            `<div><b>Uncertainty:</b><br>
+             <input type="radio" name="deadband-select" value="null" checked> Ignore Uncertainty.<br>
+             <input type="radio" name="deadband-select" value="observation_uncertainty"> Set deadband to observation uncertainty.<br>
+             <input type="radio" name="deadband-select" value="user_supplied"> Set deadband to:
+             <input type="number" step="any" min=0.0 max=100.0 name="deadband-value"> &percnt;<br></div>`);
+        // deadbandSelect.find('[name="deadband-value"]')[0].setCustomValidity(
+        //     "Must be a value from 0.0 to 100.0");
+        var db_wrapper = $('<div class="form-element full-width deadband-select-wrapper"></div>')
+        db_wrapper.append(deadbandSelect);
+        return db_wrapper;
+    }
+
+
+    function parseDeadband(){
+        /*
+         * Parses the deadband widgets into a readable display value, and a
+         * valid string value.
+         */
+        var source = $('[name="deadband-select"]:checked').val();
+        if(source == "user_supplied"){
+            var val = $('[name="deadband-value"]').val();
+            if(!$('[name="deadband-value"]')[0].reportValidity()){
+                throw 'Deadband out of range';
+            }
+            return [val, val];
+
+        }else if(source == "null"){
+            return ["Ignore uncertainty.", "null"]
+        }else if(source == "observation_uncertainty"){
+            var obs_id = $('#observation-select').val();
+            var obs = searchObjects("observations", obs_id);
+            if(obs){
+                obs_uncertainty = obs['uncertainty'].toString();
+                return [obs_uncertainty, obs_uncertainty];
+            }
+        }
     }
 
 
@@ -279,7 +377,6 @@ $(document).ready(function() {
             // if all options are hidden, show "no matching forecasts"
             if (toHide.length == forecasts.length){
                 forecast_select.val('');
-                //
                 if ($('#no-forecast-site-selection').attr('hidden') || compareTo == 'aggregate'){
                     $('#no-forecasts').removeAttr('hidden');
                 }
@@ -295,20 +392,20 @@ $(document).ready(function() {
         }
 
         function filterReferenceForecasts(variable){
+            /* Filter the list of reference forecasts based on the current
+             * forecast.
+             */
             forecast = forecast_select.find(':selected').first();
             reference_forecasts = $('#reference-forecast-select option').slice(2);
             reference_forecasts.removeAttr('hidden');
             if (forecast[0]){
-                console.log("selected forecast ", forecast);
                 if(forecast.data.hasOwnProperty('siteId')){
                     site_id = forecast.data().siteId;
                 }else{
                     aggregate_id = forecast.data().aggregateId;
                 }
                 variable = forecast.data().variable;
-                console.log('selected variable ', variable);
                 interval_length = forecast.data().intervalLength;
-                console.log('selected il ', interval_length);
                 // hide the "please select forecast" prompt"
                 $('#no-reference-forecast-forecast-selection').attr('hidden', true);
                 toHide = searchSelect('#reference-forecast-option-search',
@@ -317,7 +414,6 @@ $(document).ready(function() {
                 toHide = toHide.add(reference_forecasts.not(
                     `[data-variable=${variable}]`));
                 }
-                console.log("after var", toHide);
                 // Determine if we need to filter by site or aggregate
                 if (site_id){
                     // create a set of elements to hide from selected site, variable and search
@@ -338,10 +434,7 @@ $(document).ready(function() {
             }else{
                 toHide = reference_forecasts;
                 $('#no-reference-forecast-forecast-selection').removeAttr('hidden');
-                console.log('no forecast');
             }
-            
-            console.log("after search", toHide);
             
             // if current forecast selection is invalid, deselect
             if (toHide.filter(':selected').length){
@@ -351,7 +444,7 @@ $(document).ready(function() {
             // if all options are hidden, show "no matching forecasts"
             if (toHide.length == reference_forecasts.length){
                 ref_forecast_select.val('');
-                if ($('#no-reference-forecast-site-selection').attr('hidden') || compareTo == 'aggregate'){
+                if ($('#no-reference-forecast-forecast-selection').attr('hidden') || compareTo == 'aggregate'){
                     $('#no-reference-forecasts').removeAttr('hidden');
                 }
             } else {
@@ -388,6 +481,8 @@ $(document).ready(function() {
         }
 
         function filterObservations(){
+            /* Filter list of observations based on current site and variable.
+             */
             observations = $('#observation-select option').slice(2);
             // get the attributes of the currently selected forecast
             selectedForecast = $('#forecast-select :selected');
@@ -424,35 +519,41 @@ $(document).ready(function() {
             }
         }
 
-        // Declare handles to each field's input widgets, and insert a variable select
-        // widget for Forecast filtering.
-        var widgetContainer = $('<div class="pair-selector-wrapper collapse"></div>');
+        /*
+         * Create select widgets for creating an observatio/forecast pair, 
+         */
         var aggregateSelector = newSelector("aggregate", "forecast");
         var siteSelector = newSelector("site");
         var obsSelector = newSelector("observation", "forecast");
         var fxSelector = newSelector("forecast", "site");
         var refFxSelector = newSelector("reference forecast", "forecast", required=false);
         var fxVariableSelector = createVariableSelect();
+        var dbSelector = deadbandSelector();
         fxSelector.find('.report-field-filters').append(fxVariableSelector);
+
+        // Buttons for adding an obs/fx pair for observations or aggregates
         var addObsButton = $('<a role="button" class="btn btn-primary" id="add-obs-object-pair" style="padding-left: 1em">Add a Forecast, Observation pair</a>');
         var addAggButton = $('<a role="button" class="btn btn-primary" id="add-agg-object-pair" style="padding-left: 1em">Add a Forecast, Aggregate pair</a>');
 
 
-        // Radio button for selecting between an aggregate or site
+        // Create a radio button for selecting between aggregate or observation
         var obsAggRadio = $(`<div><b>Compare Forecast to&colon;</b>
                              <input type="radio" name="observation-aggregate-radio" value="observation" checked> Observation
                              <input type="radio" name="observation-aggregate-radio" value="aggregate">Aggregate<br/></div>`);
-        widgetContainer.append(obsAggRadio);
         radio_inputs = obsAggRadio.find('input[type=radio]');
         radio_inputs.change(determineWidgets);
 
-        // Add the elements to the widget Container, so that the single container may
-        // be inserted into the DOM
+        /*
+         * Add all of the input elements to the widget container.
+         */
+        var widgetContainer = $('<div class="pair-selector-wrapper collapse"></div>');
+        widgetContainer.append(obsAggRadio);
         widgetContainer.append(siteSelector);
         widgetContainer.append(fxSelector);
         widgetContainer.append(refFxSelector);
         widgetContainer.append(obsSelector);
         widgetContainer.append(aggregateSelector);
+        widgetContainer.append(dbSelector);
         widgetContainer.append(addObsButton);
         widgetContainer.append(addAggButton);
 
@@ -549,7 +650,12 @@ $(document).ready(function() {
                     ref_text = selected_reference_forecast.text;
                     ref_id = selected_reference_forecast.value;
                 }
-
+                // try to parse deadband values
+                try{
+                    deadband_values = parseDeadband();
+                }catch(error){
+                    return;
+                }
                 pair = addPair('observation',
                                selected_observation.text,
                                selected_observation.value,
@@ -557,6 +663,8 @@ $(document).ready(function() {
                                selected_forecast.value,
                                ref_text,
                                ref_id,
+                               deadband_values[0],
+                               deadband_values[1],
                 );
                 pair_container.append(pair);
                 pair_index++;
@@ -565,6 +673,7 @@ $(document).ready(function() {
                 $(".empty-reports-list").attr('hidden', 'hidden');
                 forecast_select.css('border', '');
                 observation_select.css('border', '');
+                toggle_reference_dependent_metrics();
             } else {
                 // Otherwise apply a red border to alert the user to need of input
                 if (forecast_select.val() == null){
@@ -590,6 +699,12 @@ $(document).ready(function() {
                     ref_text = selected_reference_forecast.text;
                     ref_id = selected_reference_forecast.value;
                 }
+                // try to parse deadband values
+                try{
+                    deadband_values = parseDeadband();
+                }catch(error){
+                    return;
+                }
                 pair = addPair('aggregate',
                                selected_aggregate.text,
                                selected_aggregate.value,
@@ -597,6 +712,8 @@ $(document).ready(function() {
                                selected_forecast.value,
                                ref_text,
                                ref_id,
+                               deadband_values[0],
+                               deadband_values[1],
                 );
                 pair_container.append(pair);
                 pair_index++;
@@ -606,6 +723,7 @@ $(document).ready(function() {
                 $(".empty-reports-list")[0].hidden = true;
                 forecast_select.css('border', '');
                 observation_select.css('border', '');
+                toggle_reference_dependent_metrics();
             } else {
                 // Otherwise apply a red border to alert the user to need of input
                 if (forecast_select.val() == null){
@@ -649,16 +767,7 @@ function validateReport(){
     // remove any existing errors
     $('#form-errors').empty();
 
-    // Assert that if skill is selected, all pairs have a reference forecast.
-    selected_metrics = $('input[name="metrics"]').map(function(){return this.value}).get();
-    reference_forecasts = $('.reference-forecast-value').map(function(){return this.value}).get();
-    if(selected_metrics.includes("s") && reference_forecasts.some((x) => x != 'Unset')){
-        insertErrorMessage(
-            "Skill Metric",
-            "Requires that all Observation, Forecast pairs have a reference forecast.");
-    }
-
-    // asset at least one pair was selected.
+    // assert at least one pair was selected.
     if($('.object-pair').length == 0){
         insertErrorMessage(
             "Analysis Pairs",

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -324,6 +324,7 @@ $(document).ready(function() {
                 $('#aggregate-select').val('');
                 $("#add-obs-object-pair").removeAttr('hidden');
                 $("#add-agg-object-pair").attr('hidden', true);
+                $('.deadband-select-wrapper').removeAttr('hidden');
                 filterForecasts();
             } else {
                 // hide sites & observations
@@ -334,6 +335,7 @@ $(document).ready(function() {
                 $('#site-select').val('');
                 $("#add-agg-object-pair").removeAttr('hidden');
                 $("#add-obs-object-pair").attr('hidden', true);
+                $('.deadband-select-wrapper').attr('hidden', true);
 
                 filterForecasts();
             }
@@ -703,12 +705,12 @@ $(document).ready(function() {
                     ref_text = selected_reference_forecast.text;
                     ref_id = selected_reference_forecast.value;
                 }
-                // try to parse deadband values
-                try{
-                    deadband_values = parseDeadband();
-                }catch(error){
-                    return;
-                }
+                // try to parse deadband values TODO
+                // try{
+                //     deadband_values = parseDeadband();
+                // }catch(error){
+                //     return;
+                // }
                 pair = addPair('aggregate',
                                selected_aggregate.text,
                                selected_aggregate.value,
@@ -716,8 +718,8 @@ $(document).ready(function() {
                                selected_forecast.value,
                                ref_text,
                                ref_id,
-                               deadband_values[0],
-                               deadband_values[1],
+                               "Unset",
+                               null,
                 );
                 pair_container.append(pair);
                 pair_index++;

--- a/sfa_dash/static/js/report-handling.js
+++ b/sfa_dash/static/js/report-handling.js
@@ -12,7 +12,11 @@ $(document).ready(function() {
         if(nulls_exist){
             // hide skill, insert warning
             skill.attr('disabled', true);
-            $('<span id="reference-warning" class="warning-message"> (Requires reference forecast selection)</span>').insertAfter(skill.next());
+            if($('#reference-warning').length == 0){
+                $(`<span id="reference-warning" class="warning-message">
+                   (Requires reference forecast selection)</span>`
+                 ).insertAfter(skill.next());
+            }
             if(skill.is(':checked')){
                 skill.removeAttr('checked');
             }

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -5,7 +5,7 @@
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
 <h3>Create New Report</h3>
-<form action="{{ url_for('forms.create_report') }}" method="post" id="report-form" onSubmit="return validateReport();">
+<form action="{{ url_for('forms.create_report') }}" method="post" id="report-form" onSubmit="validateReport();">
   <div class="form-group">
       {% if form_data is not defined %} {% set form_data = {} %}{% endif %}
      <div class="form-element full-width">

--- a/sfa_dash/templates/forms/report_form.html
+++ b/sfa_dash/templates/forms/report_form.html
@@ -5,7 +5,7 @@
 {{ metadata | safe }}
 {% include "sections/notifications.html" %}
 <h3>Create New Report</h3>
-<form action="{{ url_for('forms.create_report') }}" method="post" id="report-form">
+<form action="{{ url_for('forms.create_report') }}" method="post" id="report-form" onSubmit="return validateReport();">
   <div class="form-group">
       {% if form_data is not defined %} {% set form_data = {} %}{% endif %}
      <div class="form-element full-width">
@@ -37,7 +37,6 @@
 
      <h5>Observation, Forecast pairs</h5>
 	 <div class="form-element full-width border" style="border-radius:10px;margin:.5em 1em;">
-       <div class="form-element">Forecasts</div><div class="form-element">Observations/Aggregates</div>
        <div class="object-pair-list">
          <div class="empty-reports-list alert alert-warning">No Pairs Selected</div>
        </div>
@@ -48,10 +47,8 @@
      <div class="form-element">
      <label>Metrics</label><br>
        {% for metric, label in deterministic_metrics.items() %}
-       {% if metric != 's' %}
        <input type="checkbox" name="metrics" value="{{ metric }}" {% if form_data %}{% if metric in form_data['report_parameters']['metrics'] %}checked{% endif %}{% elif metric in default_metrics  %}checked{% endif %}>
        <a href="https://solarforecastarbiter.org/metrics/#{{ metric |replace('^', '') }}" target="_blank"> {{ label }}</a><br/>
-       {% endif %}
        {% endfor %}
      </div>
      <div class="form-element">
@@ -70,5 +67,7 @@
     {{ form.token() }}
   </div>
 </form>
-<button type="submit" form="report-form" value="Submit" class="btn btn-primary">Submit</button>
+<ul id="form-errors">
+</ul>
+<button type="submit" form="report-form" value="Submit" class="btn btn-primary" >Submit</button>
 {% endblock %}


### PR DESCRIPTION
closes #218, closes #217, closes #214 
Features updated/ added in this PR:

Updates the list of pairs to display uncertainty and reference forecast data as shown below. The first pair displays an unset uncertainty. The second pair displays an unset reference forecast, and the result of "observation_uncertainty"(note that the value transmitted to the api is the string "observation_uncertainty" , but I've displayed the value for the user here). The third pair displays user provided uncertainty. 
![Screenshot from 2020-04-06 15-11-52](https://user-images.githubusercontent.com/21206164/78610303-69a29680-7819-11ea-8adf-3632548c9b44.png)


per #217: When the first object pair is set, a units variable is set, and the available variables are limitted. 

per: #214 Adds a reference forecast selection area that is dependent on the forecast selection. This is limited to forecasts at the same site and variable and is required to have the same or shorter interval length. This results in listing most other forecasts at the same site.

![Screenshot from 2020-04-06 15-18-20](https://user-images.githubusercontent.com/21206164/78610615-1d0b8b00-781a-11ea-9382-0a5da763dcff.png)


per #218: Adds a new widget at the end of the object pair selection area to select the source of uncertainty per pair. 
![Screenshot from 2020-04-06 15-20-41](https://user-images.githubusercontent.com/21206164/78610668-36acd280-781a-11ea-963d-49544cc425e4.png)

Added a check when an object pair is added to uncheck and disable the "skill" metric and display a message if a reference forecast was not supplied. 
![Screenshot from 2020-04-06 15-22-24](https://user-images.githubusercontent.com/21206164/78610796-770c5080-781a-11ea-8fa5-ada78b744961.png)

@wholmgren Do these seem in line with what you were thinking for the updated ui?