### PR TITLE
Adjust report fxobs pair table font

### DIFF
--- a/sfa_dash/static/css/styles.css
+++ b/sfa_dash/static/css/styles.css
@@ -526,6 +526,9 @@ th.selection-column{
     word-break: break-word;
 }
 
+table.obsfx-table td{
+    font-size: .75rem;
+}
 .plot-attribute-wrapper .plot-attribute-wrapper.loading-plots::after{
     animation: 1.5s linear infinite spinner;
     animation-play-state: inherit;


### PR DESCRIPTION
Counterpart PR to https://github.com/SolarArbiter/solarforecastarbiter-core/pull/389. Just adjusts the size of font in the report Aligned pairs table to make the table less busy.